### PR TITLE
Add conflict detection for author slugs matching page slugs

### DIFF
--- a/class-obenland-wp-author-slug.php
+++ b/class-obenland-wp-author-slug.php
@@ -38,6 +38,7 @@ class Obenland_Wp_Author_Slug extends Obenland_Wp_Plugins_V5 {
 		);
 
 		$this->hook( 'pre_user_nicename' );
+		$this->hook( 'admin_notices' );
 	}
 
 	/**
@@ -71,5 +72,51 @@ class Obenland_Wp_Author_Slug extends Obenland_Wp_Plugins_V5 {
 		}
 
 		return $name;
+	}
+
+	/**
+	 * Displays admin notices for slug conflicts.
+	 *
+	 * @author Konstantin Obenland
+	 * @since  5 - 09.09.2025
+	 * @access public
+	 */
+	public function admin_notices() {
+		$conflicts = get_option( 'wp_author_slug_conflicts', array() );
+
+		if ( empty( $conflicts ) ) {
+			return;
+		}
+
+		// Only show to users who can manage users.
+		if ( ! current_user_can( 'edit_users' ) ) {
+			return;
+		}
+
+		echo '<div class="notice notice-error">';
+		echo '<p><strong>' . esc_html__( 'WP Author Slug: Conflicts Detected', 'wp-author-slug' ) . '</strong></p>';
+		echo '<p>' . esc_html__( 'The following author slugs conflict with existing page slugs. This may cause sub-pages to fail loading:', 'wp-author-slug' ) . '</p>';
+		echo '<ul>';
+
+		foreach ( $conflicts as $conflict ) {
+			$user = get_userdata( $conflict['user_id'] );
+			$page = get_post( $conflict['page_id'] );
+
+			if ( $user && $page ) {
+				$user_slug = sanitize_title( $user->display_name );
+				printf(
+					/* translators: 1: User name, 2: User slug, 3: Page edit link, 4: Page title */
+					'<li>' . wp_kses_post( __( 'User "%1$s" (slug: <code>%2$s</code>) conflicts with page: <a href="%3$s">%4$s</a>.', 'wp-author-slug' ) ) . '</li>',
+					esc_html( $user->display_name ),
+					esc_html( $user_slug ),
+					esc_url( get_edit_post_link( $page->ID ) ),
+					esc_html( $page->post_title )
+				);
+			}
+		}
+
+		echo '</ul>';
+		echo '<p>' . esc_html__( 'Please change the slug of the conflicting pages, then deactivate and reactivate this plugin to clear the conflicts.', 'wp-author-slug' ) . '</p>';
+		echo '</div>';
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: obenland
 Tags: security, slug, author, author archive, url, permalink
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=XVPLJZ3VH4GCN
 Requires at least: 3.0
-Tested up to: 6.4
-Stable tag: 4
+Tested up to: 6.8
+Stable tag: 5
 
 Add a layer of security and prevent your login name from being shown in the author archive's URL.
 
@@ -26,6 +26,10 @@ DO NOT use this on a site with more than 1000 registered users, as updating all 
 
 
 == Changelog ==
+
+= 5 =
+* Added conflict detection for author slugs that match existing page slugs. Props @knutsp.
+* Tested with WordPress 6.8.
 
 = 4 =
 * Moved clean up to plugin deactivation. This makes sure author slugs are only modified with the plugin active.
@@ -67,4 +71,4 @@ DO NOT use this on a site with more than 1000 registered users, as updating all 
 
 
 == Upgrade Notice ==
-Maintenance update.
+Added conflict detection to prevent sub-page loading issues when author slugs match page slugs.

--- a/wp-author-slug.php
+++ b/wp-author-slug.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Author Slug
  * Plugin URI:  http://en.wp.obenland.it/wp-author-slug/?utm_source=wordpress&utm_medium=plugin&utm_campaign=wp-author-slug
  * Description: Rewrites the author url to NOT display the username but the display name
- * Version:     4
+ * Version:     5
  * Author:      Konstantin Obenland
  * Author URI:  http://en.wp.obenland.it/?utm_source=wordpress&utm_medium=plugin&utm_campaign=wp-author-slug
  * Text Domain: wp-author-slug
@@ -33,15 +33,33 @@ function wp_author_slug_activation() {
 		)
 	);
 
+	$conflicts = array();
+
 	foreach ( $users as $user ) {
 		if ( ! empty( $user->display_name ) ) {
+			$proposed_slug = sanitize_title( $user->display_name );
+
+			// Check for conflicts with existing pages.
+			$existing_page = get_page_by_path( $proposed_slug );
+			if ( $existing_page ) {
+				$conflicts[] = array(
+					'user_id' => $user->ID,
+					'page_id' => $existing_page->ID,
+				);
+			}
+
 			wp_update_user(
 				array(
 					'ID'            => $user->ID,
-					'user_nicename' => sanitize_title( $user->display_name ),
+					'user_nicename' => $proposed_slug,
 				)
 			);
 		}
+	}
+
+	// Store conflicts for admin notices.
+	if ( ! empty( $conflicts ) ) {
+		update_option( 'wp_author_slug_conflicts', $conflicts );
 	}
 }
 register_activation_hook( __FILE__, 'wp_author_slug_activation' );
@@ -49,7 +67,7 @@ register_activation_hook( __FILE__, 'wp_author_slug_activation' );
 /**
  * Restores users' nicenames.
  *
- * Only runs on activation of plugin.
+ * Only runs on deactivation of plugin.
  */
 function wp_author_slug_deactivation() {
 	$users = get_users(
@@ -67,5 +85,8 @@ function wp_author_slug_deactivation() {
 			)
 		);
 	}
+
+	// Clean up stored conflicts.
+	delete_option( 'wp_author_slug_conflicts' );
 }
 register_deactivation_hook( __FILE__, 'wp_author_slug_deactivation' );


### PR DESCRIPTION
## Summary
• Detects conflicts between author display name slugs and existing page slugs during plugin activation
• Shows admin warning notice when conflicts are detected to prevent sub-page loading issues  
• Provides simple resolution process for users
• Stores minimal conflict data and dynamically fetches current information

## Test plan
- [x] Created test environment with wp-env
- [x] Added test data with conflicting page and author slugs  
- [x] Verified conflict detection works during plugin activation
- [x] Confirmed admin notices display correctly
- [x] Tested cleanup on plugin deactivation
- [x] Verified simplified conflict storage (user_id, page_id only)

## Changes
- Added `admin_notices()` method to display conflict warnings
- Modified activation hook to detect and store conflicts
- Enhanced deactivation hook to clean up conflict data
- Version bump to 5.0 with updated readme

Fixes the issue where author slugs matching page slugs cause sub-page loading failures.