### PR TITLE
Escape donate link output in plugin_row_meta

### DIFF
--- a/class-obenland-wp-plugins-v5.php
+++ b/class-obenland-wp-plugins-v5.php
@@ -125,8 +125,8 @@ class Obenland_Wp_Plugins_V5 {
 		if ( $this->plugin_name === $plugin_file ) {
 			$plugin_meta[] = sprintf(
 				'<a href="%1$s" target="_blank" title="%2$s">%2$s</a>',
-				$this->donate_link,
-				__( 'Donate', 'obenland-wp' )
+				esc_url( $this->donate_link ),
+				esc_attr__( 'Donate', 'obenland-wp' )
 			);
 		}
 

--- a/class-obenland-wp-plugins-v5.php
+++ b/class-obenland-wp-plugins-v5.php
@@ -123,10 +123,12 @@ class Obenland_Wp_Plugins_V5 {
 	 */
 	public function plugin_row_meta( $plugin_meta, $plugin_file ) {
 		if ( $this->plugin_name === $plugin_file ) {
+			$label         = __( 'Donate', 'obenland-wp' );
 			$plugin_meta[] = sprintf(
-				'<a href="%1$s" target="_blank" title="%2$s">%2$s</a>',
+				'<a href="%1$s" target="_blank" rel="noopener noreferrer" title="%2$s">%3$s</a>',
 				esc_url( $this->donate_link ),
-				esc_attr__( 'Donate', 'obenland-wp' )
+				esc_attr( $label ),
+				esc_html( $label )
 			);
 		}
 

--- a/tests/test-wp-author-slug.php
+++ b/tests/test-wp-author-slug.php
@@ -377,7 +377,8 @@ class Test_WP_Author_Slug extends WP_UnitTestCase {
 
 	/**
 	 * Tests that `plugin_row_meta` appends a Donate link when the file matches
-	 * this plugin and that the rendered URL points at PayPal.
+	 * this plugin, the rendered URL points at PayPal, and the anchor carries
+	 * `rel="noopener noreferrer"` to mitigate reverse-tabnabbing.
 	 */
 	public function test_plugin_row_meta_appends_donate_link_for_this_plugin() {
 		$instance = Obenland_Wp_Author_Slug::get_instance();
@@ -387,6 +388,7 @@ class Test_WP_Author_Slug extends WP_UnitTestCase {
 		$this->assertCount( 1, $meta );
 		$this->assertStringContainsString( '>Donate</a>', $meta[0] );
 		$this->assertStringContainsString( 'paypal.com/cgi-bin/webscr', $meta[0] );
+		$this->assertStringContainsString( 'rel="noopener noreferrer"', $meta[0] );
 	}
 
 	/**

--- a/tests/test-wp-author-slug.php
+++ b/tests/test-wp-author-slug.php
@@ -361,6 +361,104 @@ class Test_WP_Author_Slug extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Reads the protected `plugin_name` from the singleton via reflection so
+	 * tests do not have to hard-code the basename WordPress uses to identify
+	 * this plugin file (which depends on the test harness's plugin layout).
+	 *
+	 * @return string The plugin basename WordPress uses for plugin_row_meta.
+	 */
+	private function get_plugin_name() {
+		$instance   = Obenland_Wp_Author_Slug::get_instance();
+		$reflection = new ReflectionObject( $instance );
+		$property   = $reflection->getProperty( 'plugin_name' );
+		$property->setAccessible( true );
+		return $property->getValue( $instance );
+	}
+
+	/**
+	 * Tests that `plugin_row_meta` appends a Donate link when the file matches
+	 * this plugin and that the rendered URL points at PayPal.
+	 */
+	public function test_plugin_row_meta_appends_donate_link_for_this_plugin() {
+		$instance = Obenland_Wp_Author_Slug::get_instance();
+
+		$meta = $instance->plugin_row_meta( array(), $this->get_plugin_name() );
+
+		$this->assertCount( 1, $meta );
+		$this->assertStringContainsString( '>Donate</a>', $meta[0] );
+		$this->assertStringContainsString( 'paypal.com/cgi-bin/webscr', $meta[0] );
+	}
+
+	/**
+	 * Tests that `plugin_row_meta` returns the existing meta unchanged when the
+	 * row belongs to a different plugin.
+	 */
+	public function test_plugin_row_meta_passes_through_for_other_plugins() {
+		$instance = Obenland_Wp_Author_Slug::get_instance();
+		$existing = array( 'Existing meta' );
+
+		$this->assertSame(
+			$existing,
+			$instance->plugin_row_meta( $existing, 'other-plugin/other-plugin.php' )
+		);
+	}
+
+	/**
+	 * Tests that `plugin_row_meta` escapes the donate URL through `esc_url()`
+	 * so a compromised `donate_link` cannot inject the `javascript:` protocol
+	 * or break out of the `href` attribute.
+	 */
+	public function test_plugin_row_meta_escapes_donate_url() {
+		$instance   = Obenland_Wp_Author_Slug::get_instance();
+		$reflection = new ReflectionObject( $instance );
+		$property   = $reflection->getProperty( 'donate_link' );
+		$property->setAccessible( true );
+		$original = $property->getValue( $instance );
+
+		try {
+			$property->setValue( $instance, 'javascript:alert(1)" onclick="alert(2)' );
+
+			$meta = $instance->plugin_row_meta( array(), $this->get_plugin_name() );
+
+			$this->assertNotEmpty( $meta );
+			/* esc_url() strips disallowed protocols entirely. */
+			$this->assertStringNotContainsString( 'javascript:', $meta[0] );
+			/* The injected attribute breakout must not survive escaping. */
+			$this->assertStringNotContainsString( 'onclick="alert(2)"', $meta[0] );
+		} finally {
+			$property->setValue( $instance, $original );
+		}
+	}
+
+	/**
+	 * Tests that `plugin_row_meta` escapes the translated `Donate` label so a
+	 * tampered translation cannot inject markup into the `title` attribute or
+	 * the link text.
+	 */
+	public function test_plugin_row_meta_escapes_donate_label() {
+		$malicious = '"><script>alert(1)</script>';
+		$filter    = static function ( $translation, $text, $domain ) use ( $malicious ) {
+			if ( 'obenland-wp' === $domain && 'Donate' === $text ) {
+				return $malicious;
+			}
+			return $translation;
+		};
+		add_filter( 'gettext', $filter, 10, 3 );
+
+		try {
+			$instance = Obenland_Wp_Author_Slug::get_instance();
+			$meta     = $instance->plugin_row_meta( array(), $this->get_plugin_name() );
+
+			$this->assertNotEmpty( $meta );
+			/* The raw payload must never survive into the rendered markup. */
+			$this->assertStringNotContainsString( $malicious, $meta[0] );
+			$this->assertStringNotContainsString( '<script>', $meta[0] );
+		} finally {
+			remove_filter( 'gettext', $filter, 10 );
+		}
+	}
+
+	/**
 	 * Tests that `admin_notices` skips conflict entries whose user or page no
 	 * longer exists, rather than emitting a malformed list item or triggering
 	 * a fatal error on a null user/page.


### PR DESCRIPTION
## Summary

- Wrap `$this->donate_link` in `esc_url()` and the translated `Donate` label in `esc_attr__()` inside `Obenland_Wp_Plugins_V5::plugin_row_meta()` so a tampered `.mo` translation or any future change exposing `donate_link` to external input can't break out of the `href`/`title` attributes.
- The values are server-controlled today, so this is defense-in-depth — surfaced by a security audit pass over the codebase.
- Add four PHPUnit tests covering the happy path, the non-matching plugin pass-through, and two negative cases that inject malicious payloads (`javascript:alert(1)" onclick="alert(2)` via reflection, `"><script>alert(1)</script>` via the `gettext` filter) and assert they don't survive escaping.

## Test plan

- [x] `composer test` — single-site, 20/20 passing
- [x] `composer test-multisite` — 20/20 passing
- [x] `vendor/bin/phpcs --standard=WordPress` on changed files — clean
- [x] Reverted the fix locally and confirmed both XSS tests fail with the unescaped payloads visible in output, then re-applied and confirmed they pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)