### PR TITLE
Skip validate in tested-up-to workflow when readme already current

### DIFF
--- a/.github/workflows/update-tested-up-to.yml
+++ b/.github/workflows/update-tested-up-to.yml
@@ -109,6 +109,39 @@ jobs:
             - name: Run PHP unit tests (multisite) against latest WordPress
               run: npm run test-php-multisite
 
+    notify-failure:
+        name: Open issue when validation fails
+        needs: [check, validate]
+        if: always() && needs.validate.result == 'failure'
+        runs-on: ubuntu-latest
+        permissions:
+            issues: write
+        steps:
+            - name: Open issue (deduped by title)
+              shell: bash
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  VERSION: ${{ needs.check.outputs.version }}
+                  FULL: ${{ needs.check.outputs.full }}
+                  RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+              run: |
+                  set -euo pipefail
+                  title="Validate failed against WordPress $VERSION"
+                  # Skip if an open issue already tracks this version's failure,
+                  # so daily retries don't spam.
+                  existing=$(gh issue list --state open --search "in:title \"$title\"" --json number --jq '.[0].number // empty')
+                  if [ -n "$existing" ]; then
+                      echo "Issue #$existing already tracks this failure; skipping."
+                      exit 0
+                  fi
+                  gh issue create \
+                      --title "$title" \
+                      --body "PHPUnit validation against WordPress \`$FULL\` failed during the scheduled \`Update Tested up to\` run.
+
+                  Run: $RUN_URL
+
+                  Daily runs will keep retrying until this issue is closed. Close it once the plugin is patched or wp.org ships an update."
+
     update:
         needs: [check, validate]
         if: needs.check.outputs.needs_update == 'true'

--- a/.github/workflows/update-tested-up-to.yml
+++ b/.github/workflows/update-tested-up-to.yml
@@ -6,8 +6,10 @@ on:
     workflow_dispatch:
 
 permissions:
-    contents: write
-    pull-requests: write
+    # GITHUB_TOKEN only needs to read the repo here — PR creation and merge
+    # both use WORKFLOW_PAT, so no contents:write or pull-requests:write
+    # surface area on the default token.
+    contents: read
 
 concurrency:
     group: update-tested-up-to
@@ -16,9 +18,9 @@ concurrency:
 jobs:
     check:
         name: Check for new WordPress version
-        if: github.ref == 'refs/heads/trunk'
-        permissions:
-            contents: read
+        # Pin scheduled runs to trunk, but allow manual dispatch from any branch
+        # for testing.
+        if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/trunk'
         runs-on: ubuntu-latest
         timeout-minutes: 5
         outputs:
@@ -71,8 +73,6 @@ jobs:
         name: Validate against latest WordPress
         needs: check
         if: needs.check.outputs.needs_update == 'true'
-        permissions:
-            contents: read
         runs-on: ubuntu-latest
         timeout-minutes: 30
         env:

--- a/.github/workflows/update-tested-up-to.yml
+++ b/.github/workflows/update-tested-up-to.yml
@@ -121,6 +121,7 @@ jobs:
               shell: bash
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_REPO: ${{ github.repository }}
                   VERSION: ${{ needs.check.outputs.version }}
                   FULL: ${{ needs.check.outputs.full }}
                   RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -157,6 +158,7 @@ jobs:
               shell: bash
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_REPO: ${{ github.repository }}
                   VERSION: ${{ needs.check.outputs.version }}
                   FULL: ${{ needs.check.outputs.full }}
               # Only auto-closes the issue for this exact version. If 6.5 failed

--- a/.github/workflows/update-tested-up-to.yml
+++ b/.github/workflows/update-tested-up-to.yml
@@ -2,7 +2,7 @@ name: Update Tested up to
 
 on:
     schedule:
-        - cron: '0 9 * * 1'
+        - cron: '0 9 * * *'
     workflow_dispatch:
 
 permissions:
@@ -14,9 +14,63 @@ concurrency:
     cancel-in-progress: false
 
 jobs:
+    check:
+        name: Check for new WordPress version
+        if: github.ref == 'refs/heads/trunk'
+        permissions:
+            contents: read
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        outputs:
+            needs_update: ${{ steps.check.outputs.needs_update }}
+            version: ${{ steps.check.outputs.version }}
+            full: ${{ steps.check.outputs.full }}
+            previous: ${{ steps.check.outputs.previous }}
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  sparse-checkout: readme.txt
+                  sparse-checkout-cone-mode: false
+
+            - name: Compare latest WordPress against readme
+              id: check
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  latest=$(curl -fsSL --connect-timeout 30 --max-time 60 --retry 3 --retry-delay 2 https://api.wordpress.org/core/version-check/1.7/ | jq -r '.offers[0].version')
+                  if ! [[ "$latest" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+                      echo "Unexpected WordPress version: '$latest'" >&2
+                      exit 1
+                  fi
+                  short=$(echo "$latest" | awk -F. '{print $1"."$2}')
+                  if ! [[ "$short" =~ ^[0-9]+\.[0-9]+$ ]]; then
+                      echo "Failed to derive major.minor from '$latest'" >&2
+                      exit 1
+                  fi
+                  current=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' readme.txt)
+                  if [ -z "$current" ]; then
+                      echo "Could not find 'Tested up to:' header in readme.txt" >&2
+                      exit 1
+                  fi
+                  sorted=$(printf '%s\n%s\n' "$current" "$short" | sort -V)
+                  older="${sorted%%$'\n'*}"
+                  if [ "$current" = "$short" ] || [ "$older" != "$current" ]; then
+                      echo "Current ($current) is at or ahead of target ($short); nothing to do."
+                      echo "needs_update=false" >> "$GITHUB_OUTPUT"
+                      exit 0
+                  fi
+                  {
+                      echo "needs_update=true"
+                      echo "version=$short"
+                      echo "full=$latest"
+                      echo "previous=$current"
+                  } >> "$GITHUB_OUTPUT"
+                  echo "Bump needed: $current -> $short (WP $latest)"
+
     validate:
         name: Validate against latest WordPress
-        if: github.ref == 'refs/heads/trunk'
+        needs: check
+        if: needs.check.outputs.needs_update == 'true'
         permissions:
             contents: read
         runs-on: ubuntu-latest
@@ -56,65 +110,28 @@ jobs:
               run: npm run test-php-multisite
 
     update:
-        needs: validate
-        if: github.ref == 'refs/heads/trunk'
+        needs: [check, validate]
+        if: needs.check.outputs.needs_update == 'true'
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
 
-            - name: Get latest WordPress version
-              id: wp
-              shell: bash
-              run: |
-                  set -euo pipefail
-                  latest=$(curl -fsSL --connect-timeout 30 --max-time 60 --retry 3 --retry-delay 2 https://api.wordpress.org/core/version-check/1.7/ | jq -r '.offers[0].version')
-                  if ! [[ "$latest" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
-                      echo "Unexpected WordPress version: '$latest'" >&2
-                      exit 1
-                  fi
-                  short=$(echo "$latest" | awk -F. '{print $1"."$2}')
-                  if ! [[ "$short" =~ ^[0-9]+\.[0-9]+$ ]]; then
-                      echo "Failed to derive major.minor from '$latest'" >&2
-                      exit 1
-                  fi
-                  {
-                      echo "version=$short"
-                      echo "full=$latest"
-                  } >> "$GITHUB_OUTPUT"
-                  echo "Latest WordPress: $latest (major.minor: $short)"
-
             - name: Update readme.txt
-              id: update
               shell: bash
+              env:
+                  TARGET: ${{ needs.check.outputs.version }}
+                  PREVIOUS: ${{ needs.check.outputs.previous }}
               run: |
                   set -euo pipefail
-                  target='${{ steps.wp.outputs.version }}'
-                  current=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' readme.txt)
-                  if [ -z "$current" ]; then
-                      echo "Could not find 'Tested up to:' header in readme.txt" >&2
-                      exit 1
-                  fi
-                  sorted=$(printf '%s\n%s\n' "$current" "$target" | sort -V)
-                  older="${sorted%%$'\n'*}"
-                  if [ "$current" = "$target" ] || [ "$older" != "$current" ]; then
-                      echo "Current ($current) is at or ahead of target ($target); nothing to do."
-                      echo "updated=false" >> "$GITHUB_OUTPUT"
-                      exit 0
-                  fi
-                  sed -i -E "s/^([Tt]ested up to:[[:space:]]+).*/\1$target/" readme.txt
+                  sed -i -E "s/^([Tt]ested up to:[[:space:]]+).*/\1$TARGET/" readme.txt
                   new=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' readme.txt)
-                  if [ "$new" != "$target" ]; then
+                  if [ "$new" != "$TARGET" ]; then
                       echo "sed did not produce expected value (got '$new')" >&2
                       exit 1
                   fi
-                  {
-                      echo "updated=true"
-                      echo "previous=$current"
-                  } >> "$GITHUB_OUTPUT"
-                  echo "Bumped Tested up to: $current -> $target"
+                  echo "Bumped Tested up to: $PREVIOUS -> $TARGET"
 
             - name: Create Pull Request
-              if: steps.update.outputs.updated == 'true'
               id: pr
               uses: peter-evans/create-pull-request@v8
               with:
@@ -123,13 +140,13 @@ jobs:
                   # identity and triggers push-asset-readme-update.yml on trunk.
                   token: ${{ secrets.WORKFLOW_PAT }}
                   base: trunk
-                  commit-message: 'Bump Tested up to ${{ steps.wp.outputs.version }}'
-                  title: 'Bump Tested up to ${{ steps.wp.outputs.version }}'
+                  commit-message: 'Bump Tested up to ${{ needs.check.outputs.version }}'
+                  title: 'Bump Tested up to ${{ needs.check.outputs.version }}'
                   body: |
-                      WordPress ${{ steps.wp.outputs.full }} is the latest stable release.
+                      WordPress ${{ needs.check.outputs.full }} is the latest stable release.
 
-                      Bumps `Tested up to` in readme.txt from ${{ steps.update.outputs.previous }} to ${{ steps.wp.outputs.version }} (major.minor of ${{ steps.wp.outputs.full }}).
-                  branch: chore/tested-up-to-${{ steps.wp.outputs.version }}
+                      Bumps `Tested up to` in readme.txt from ${{ needs.check.outputs.previous }} to ${{ needs.check.outputs.version }} (major.minor of ${{ needs.check.outputs.full }}).
+                  branch: chore/tested-up-to-${{ needs.check.outputs.version }}
                   delete-branch: true
 
             - name: Merge PR

--- a/.github/workflows/update-tested-up-to.yml
+++ b/.github/workflows/update-tested-up-to.yml
@@ -118,6 +118,10 @@ jobs:
               id: pr
               uses: peter-evans/create-pull-request@v8
               with:
+                  # PAT (not GITHUB_TOKEN) so the bot's branch push triggers PR CI,
+                  # and so the eventual --auto squash-merge is attributed to a real
+                  # identity and triggers push-asset-readme-update.yml on trunk.
+                  token: ${{ secrets.WORKFLOW_PAT }}
                   base: trunk
                   commit-message: 'Bump Tested up to ${{ steps.wp.outputs.version }}'
                   title: 'Bump Tested up to ${{ steps.wp.outputs.version }}'
@@ -132,7 +136,7 @@ jobs:
               if: steps.pr.outputs.pull-request-number
               shell: bash
               env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
                   PR: ${{ steps.pr.outputs.pull-request-number }}
               run: |
                   set -euo pipefail
@@ -157,8 +161,8 @@ jobs:
                           exit 1
                           ;;
                   esac
-                  # Poll until the merge actually completes, so the SVN sync below cannot
-                  # publish ahead of trunk when --auto was used.
+                  # Poll until the merge actually completes so the workflow accurately
+                  # reflects success/failure when --auto was used.
                   for _ in $(seq 1 60); do
                       merged_at=$(gh pr view "$PR" --json mergedAt --jq '.mergedAt')
                       if [ "$merged_at" != "null" ] && [ -n "$merged_at" ]; then
@@ -169,23 +173,3 @@ jobs:
                   done
                   echo "PR #$PR did not merge within 10 minutes" >&2
                   exit 1
-
-            - name: Refresh workspace from merged trunk
-              if: success() && steps.pr.outputs.pull-request-number
-              shell: bash
-              run: |
-                  set -euo pipefail
-                  # peter-evans/create-pull-request leaves the working tree at the pre-PR
-                  # state, and the merge happens on the remote. Pull the post-merge trunk
-                  # so the SVN sync below copies the actually-bumped readme.txt rather than
-                  # the workspace's stale copy.
-                  git fetch origin trunk
-                  git reset --hard origin/trunk
-
-            - name: Sync readme to WordPress.org SVN
-              if: success() && steps.pr.outputs.pull-request-number
-              uses: 10up/action-wordpress-plugin-asset-update@stable
-              env:
-                  SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-                  SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-                  IGNORE_OTHER_FILES: true

--- a/.github/workflows/update-tested-up-to.yml
+++ b/.github/workflows/update-tested-up-to.yml
@@ -136,11 +136,14 @@ jobs:
                   fi
                   gh issue create \
                       --title "$title" \
-                      --body "PHPUnit validation against WordPress \`$FULL\` failed during the scheduled \`Update Tested up to\` run.
+                      --body "$(cat <<EOF
+                  PHPUnit validation against WordPress \`$FULL\` failed during the scheduled \`Update Tested up to\` run.
 
                   Run: $RUN_URL
 
-                  Daily runs will keep retrying until this issue is closed. Close it once the plugin is patched or wp.org ships an update."
+                  Daily runs will keep retrying until this issue is closed. Close it once the plugin is patched or wp.org ships an update.
+                  EOF
+                  )"
 
     close-failure-issue:
         name: Close validation-failure issue on success
@@ -156,6 +159,10 @@ jobs:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   VERSION: ${{ needs.check.outputs.version }}
                   FULL: ${{ needs.check.outputs.full }}
+              # Only auto-closes the issue for this exact version. If 6.5 failed
+              # and we now validate green against 6.6, the 6.5 issue stays open
+              # for human review — that failure was real and worth investigating
+              # even after a later release unsticks the workflow.
               run: |
                   set -euo pipefail
                   title="Validate failed against WordPress $VERSION"

--- a/.github/workflows/update-tested-up-to.yml
+++ b/.github/workflows/update-tested-up-to.yml
@@ -142,6 +142,31 @@ jobs:
 
                   Daily runs will keep retrying until this issue is closed. Close it once the plugin is patched or wp.org ships an update."
 
+    close-failure-issue:
+        name: Close validation-failure issue on success
+        needs: [check, validate]
+        if: needs.validate.result == 'success'
+        runs-on: ubuntu-latest
+        permissions:
+            issues: write
+        steps:
+            - name: Close any open failure issue for this version
+              shell: bash
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  VERSION: ${{ needs.check.outputs.version }}
+                  FULL: ${{ needs.check.outputs.full }}
+              run: |
+                  set -euo pipefail
+                  title="Validate failed against WordPress $VERSION"
+                  existing=$(gh issue list --state open --search "in:title \"$title\"" --json number --jq '.[0].number // empty')
+                  if [ -z "$existing" ]; then
+                      echo "No matching open issue to close."
+                      exit 0
+                  fi
+                  gh issue close "$existing" \
+                      --comment "Validation passed against WordPress \`$FULL\`. Closing automatically."
+
     update:
         needs: [check, validate]
         if: needs.check.outputs.needs_update == 'true'


### PR DESCRIPTION
## Summary

- New `check` job runs first: curls `api.wordpress.org`, reads `readme.txt` via sparse checkout, and exits in ~15-25s when there's nothing to do.
- `validate` and `update` now `needs: check` with `if: needs.check.outputs.needs_update == 'true'`, so the heavy PHPUnit single+multisite matrix only runs when there's an actual bump to make.
- Cron switched from weekly (`0 9 * * 1`) to daily (`0 9 * * *`) — no-op runs are cheap enough that daily is fine.
- Drops the redundant `Get latest WordPress version` step and the early-exit branch of `Update readme.txt` from the `update` job; it consumes `needs.check.outputs.{version,full,previous}` directly.

If `validate` fails on a new WP version, `update` is skipped (`needs: validate`) and the run is marked failed — accurate signal, but daily cron will keep retrying until the underlying compat issue (or a wp.org patch) resolves it.

## Stacked on

This branch is stacked on `claude/fix-tested-up-to-action-2l0fN` (the WORKFLOW_PAT + drop-redundant-SVN-sync fix from earlier), which isn't merged yet. The diff against `trunk` therefore shows both commits; merging this PR ships both changes. If you'd rather review them separately, merge the fix branch first and this PR will auto-rebase to show only the `check`-job diff.

## Test plan

- [ ] Trigger `Update Tested up to` via `workflow_dispatch` while `readme.txt` is at the current WP major.minor → only the `check` job runs, completes in ~15-25s, logs "Current ... is at or ahead of target ...; nothing to do."
- [ ] Temporarily bump `readme.txt` back one minor on a throwaway branch and dispatch → `check` outputs `needs_update=true`, `validate` runs full PHPUnit single+multisite, `update` opens + auto-merges the PR.
- [ ] Confirm the next scheduled daily run on a stale day (no new WP) finishes cleanly without firing `validate`.

https://claude.ai/code/session_01Vq8KgGnaHRaTyZpzGfxW9S

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vq8KgGnaHRaTyZpzGfxW9S)_