### PR TITLE
Release version 6

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: security, slug, author, author archive, url, permalink
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=XVPLJZ3VH4GCN
 Requires at least: 3.0
 Tested up to: 6.9
-Stable tag: 5
+Stable tag: 6
 
 Add a layer of security and prevent your login name from being shown in the author archive's URL.
 
@@ -26,6 +26,10 @@ DO NOT use this on a site with more than 1000 registered users, as updating all 
 
 
 == Changelog ==
+
+= 6 =
+* Escaped donate link output in `plugin_row_meta` to harden against malformed URLs.
+* Tested with WordPress 6.9.
 
 = 5 =
 * Added conflict detection for author slugs that match existing page slugs. Props @knutsp.
@@ -71,4 +75,4 @@ DO NOT use this on a site with more than 1000 registered users, as updating all 
 
 
 == Upgrade Notice ==
-Added conflict detection to prevent sub-page loading issues when author slugs match page slugs.
+Hardened donate link escaping in the plugin row meta. Tested with WordPress 6.9.

--- a/wp-author-slug.php
+++ b/wp-author-slug.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Author Slug
  * Plugin URI:  http://en.wp.obenland.it/wp-author-slug/?utm_source=wordpress&utm_medium=plugin&utm_campaign=wp-author-slug
  * Description: Rewrites the author url to NOT display the username but the display name
- * Version:     5
+ * Version:     6
  * Author:      Konstantin Obenland
  * Author URI:  http://en.wp.obenland.it/?utm_source=wordpress&utm_medium=plugin&utm_campaign=wp-author-slug
  * Text Domain: wp-author-slug


### PR DESCRIPTION
## Summary

- Bumps `Version:` (wp-author-slug.php) and `Stable tag:` (readme.txt) from 5 to 6.
- Adds `= 6 =` changelog block covering the unshipped escaping fix (#34) and the 6.9 Tested-up-to bump (#35).
- Refreshes the Upgrade Notice for the new release.

## Why now

The asset/readme sync workflow has been failing since #34 because `10up/action-wordpress-plugin-asset-update` only ships `readme.txt`/`assets/` and refuses when other files differ from SVN. `class-obenland-wp-plugins-v5.php` has been out of sync with the wp.org SVN trunk since #34, so the 6.9 readme bump from #35 also couldn't ship. Cutting release 6 takes the full `deploy.yml` path and gets both changes live.

## Test plan

- [ ] Merge to trunk.
- [ ] `git tag 6 && git push origin 6` → confirm `deploy.yml` runs `10up/action-wordpress-plugin-deploy` to wp.org SVN and `release.yml` cuts a GitHub release.
- [ ] Verify wp.org plugin page reflects v6 with Tested up to 6.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)