### PR TITLE
Scope asset sync trigger to readme/asset paths

### DIFF
--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -3,6 +3,15 @@ on:
     push:
         branches:
             - trunk
+        # Only fire when the push actually touches files this workflow can ship.
+        # 10up/action-wordpress-plugin-asset-update refuses to deploy if any
+        # non-asset/readme file differs from SVN trunk, so a code-only push
+        # would always exit 1. If this workflow still fails after a readme/asset
+        # push, trunk has unshipped code from a prior commit — cut a release tag
+        # to publish via deploy.yml instead.
+        paths:
+            - readme.txt
+            - .wordpress-org/**
 jobs:
     trunk:
         name: Push to trunk


### PR DESCRIPTION
## Summary

- Adds a `paths:` filter to `push-asset-readme-update.yml` so it only fires when the push actually touches `readme.txt` or `.wordpress-org/**`.
- Adds a comment pointing readers at the right fix (cut a release tag) for the remaining failure mode where a readme/asset push lands on a trunk with unshipped code.

## Why

`10up/action-wordpress-plugin-asset-update` only ships `readme.txt` and `.wordpress-org/` assets, and exits 1 if any other tracked file differs from SVN trunk. Today the workflow runs on every push to trunk, so any code-only commit produces a red CI ✗ even though there's nothing for the workflow to do. The action takes no inputs, so this has to be solved at the workflow level. Restricting the trigger to readme/asset paths eliminates the false failures from code-only pushes.

If a readme/asset push lands on trunk while code from a prior PR is still unshipped (the situation that caused the recent `Plugin asset/readme update` failures on PR #34 → PR #35 → PR #37), this filter doesn't fix that — the fix there is to cut a release tag, which the comment in the workflow documents.

## Test plan

- [ ] Merge to trunk; verify the workflow does not fire on this PR's merge (no `readme.txt`/`.wordpress-org/**` change).
- [ ] On a follow-up readme-only push to trunk (e.g., the next auto-bump from `update-tested-up-to.yml`), verify the workflow fires and either succeeds or fails for a real reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)