### PR TITLE
Pin patched versions of vulnerable transitive deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3877,6 +3877,436 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
+		"node_modules/@jsonjoy.com/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/buffers": {
+			"version": "17.67.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-17.67.0.tgz",
+			"integrity": "sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/codegen": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-1.0.0.tgz",
+			"integrity": "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-core": {
+			"version": "4.57.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.57.2.tgz",
+			"integrity": "sha512-SVjwklkpIV5wrynpYtuYnfYH1QF4/nDuLBX7VXdb+3miglcAgBVZb/5y0cOsehRV/9Vb+3UqhkMq3/NR3ztdkQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/fs-node-builtins": "4.57.2",
+				"@jsonjoy.com/fs-node-utils": "4.57.2",
+				"thingies": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-fsa": {
+			"version": "4.57.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.57.2.tgz",
+			"integrity": "sha512-fhO8+iR2I+OCw668ISDJdn1aArc9zx033sWejIyzQ8RBeXa9bDSaUeA3ix0poYOfrj1KdOzytmYNv2/uLDfV6g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/fs-core": "4.57.2",
+				"@jsonjoy.com/fs-node-builtins": "4.57.2",
+				"@jsonjoy.com/fs-node-utils": "4.57.2",
+				"thingies": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-node": {
+			"version": "4.57.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.57.2.tgz",
+			"integrity": "sha512-nX2AdL6cOFwLdju9G4/nbRnYevmCJbh7N7hvR3gGm97Cs60uEjyd0rpR+YBS7cTg175zzl22pGKXR5USaQMvKg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/fs-core": "4.57.2",
+				"@jsonjoy.com/fs-node-builtins": "4.57.2",
+				"@jsonjoy.com/fs-node-utils": "4.57.2",
+				"@jsonjoy.com/fs-print": "4.57.2",
+				"@jsonjoy.com/fs-snapshot": "4.57.2",
+				"glob-to-regex.js": "^1.0.0",
+				"thingies": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-node-builtins": {
+			"version": "4.57.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.57.2.tgz",
+			"integrity": "sha512-xhiegylRmhw43Ki2HO1ZBL7DQ5ja/qpRsL29VtQ2xuUHiuDGbgf2uD4p9Qd8hJI5P6RCtGYD50IXHXVq/Ocjcg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-node-to-fsa": {
+			"version": "4.57.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.57.2.tgz",
+			"integrity": "sha512-18LmWTSONhoAPW+IWRuf8w/+zRolPFGPeGwMxlAhhfY11EKzX+5XHDBPAw67dBF5dxDErHJbl40U+3IXSDRXSQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/fs-fsa": "4.57.2",
+				"@jsonjoy.com/fs-node-builtins": "4.57.2",
+				"@jsonjoy.com/fs-node-utils": "4.57.2"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-node-utils": {
+			"version": "4.57.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.57.2.tgz",
+			"integrity": "sha512-rsPSJgekz43IlNbLyAM/Ab+ouYLWGp5DDBfYBNNEqDaSpsbXfthBn29Q4muFA9L0F+Z3mKo+CWlgSCXrf+mOyQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/fs-node-builtins": "4.57.2"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-print": {
+			"version": "4.57.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.57.2.tgz",
+			"integrity": "sha512-wK9NSow48i4DbDl9F1CQE5TqnyZOJ04elU3WFG5aJ76p+YxO/ulyBBQvKsessPxdo381Bc2pcEoyPujMOhcRqQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/fs-node-utils": "4.57.2",
+				"tree-dump": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-snapshot": {
+			"version": "4.57.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.57.2.tgz",
+			"integrity": "sha512-GdduDZuoP5V/QCgJkx9+BZ6SC0EZ/smXAdTS7PfMqgMTGXLlt/bH/FqMYaqB9JmLf05sJPtO0XRbAwwkEEPbVw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/buffers": "^17.65.0",
+				"@jsonjoy.com/fs-node-utils": "4.57.2",
+				"@jsonjoy.com/json-pack": "^17.65.0",
+				"@jsonjoy.com/util": "^17.65.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/base64": {
+			"version": "17.67.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-17.67.0.tgz",
+			"integrity": "sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/codegen": {
+			"version": "17.67.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-17.67.0.tgz",
+			"integrity": "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pack": {
+			"version": "17.67.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-17.67.0.tgz",
+			"integrity": "sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/base64": "17.67.0",
+				"@jsonjoy.com/buffers": "17.67.0",
+				"@jsonjoy.com/codegen": "17.67.0",
+				"@jsonjoy.com/json-pointer": "17.67.0",
+				"@jsonjoy.com/util": "17.67.0",
+				"hyperdyperid": "^1.2.0",
+				"thingies": "^2.5.0",
+				"tree-dump": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pointer": {
+			"version": "17.67.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-17.67.0.tgz",
+			"integrity": "sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/util": "17.67.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/util": {
+			"version": "17.67.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-17.67.0.tgz",
+			"integrity": "sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/buffers": "17.67.0",
+				"@jsonjoy.com/codegen": "17.67.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/json-pack": {
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.21.0.tgz",
+			"integrity": "sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/base64": "^1.1.2",
+				"@jsonjoy.com/buffers": "^1.2.0",
+				"@jsonjoy.com/codegen": "^1.0.0",
+				"@jsonjoy.com/json-pointer": "^1.0.2",
+				"@jsonjoy.com/util": "^1.9.0",
+				"hyperdyperid": "^1.2.0",
+				"thingies": "^2.5.0",
+				"tree-dump": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/json-pack/node_modules/@jsonjoy.com/buffers": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+			"integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/json-pointer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-1.0.2.tgz",
+			"integrity": "sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/codegen": "^1.0.0",
+				"@jsonjoy.com/util": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/util": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.9.0.tgz",
+			"integrity": "sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/buffers": "^1.0.0",
+				"@jsonjoy.com/codegen": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/util/node_modules/@jsonjoy.com/buffers": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+			"integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
 		"node_modules/@keyv/serialize": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
@@ -3929,6 +4359,19 @@
 			"license": "MIT",
 			"dependencies": {
 				"eslint-scope": "5.1.1"
+			}
+		},
+		"node_modules/@noble/hashes": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+			"integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/@nodable/entities": {
@@ -5505,14 +5948,183 @@
 				"third-party-web": "latest"
 			}
 		},
+		"node_modules/@peculiar/asn1-cms": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.7.0.tgz",
+			"integrity": "sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.7.0",
+				"@peculiar/asn1-x509": "^2.7.0",
+				"@peculiar/asn1-x509-attr": "^2.7.0",
+				"asn1js": "^3.0.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-csr": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.7.0.tgz",
+			"integrity": "sha512-VVsAyGqErT9D1SY4aEqozThXMVI+ssVRiv2DDeYuvpBKLIgZ3hYs3Ay3u/VSoKq6ESFi9cf6rf3IOOzfwh7oMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.7.0",
+				"@peculiar/asn1-x509": "^2.7.0",
+				"asn1js": "^3.0.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-ecc": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.7.0.tgz",
+			"integrity": "sha512-n7KEs/Q/wrB415cxy4fHOBhegp4NdJ15fkJPwcB/3/8iNBQC2L/N7SChJPKDJPZGYH0jD4Tg4/0vnHmwghnbKw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.7.0",
+				"@peculiar/asn1-x509": "^2.7.0",
+				"asn1js": "^3.0.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-pfx": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.7.0.tgz",
+			"integrity": "sha512-V/nrlQVmhg7lYAsM7E13UDL5erAwFv6kCIVFqNaMIHSVi7dngcT839JkRTkQBqznMG98l2XjxYk74ZztAohZzA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-cms": "^2.7.0",
+				"@peculiar/asn1-pkcs8": "^2.7.0",
+				"@peculiar/asn1-rsa": "^2.7.0",
+				"@peculiar/asn1-schema": "^2.7.0",
+				"asn1js": "^3.0.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-pkcs8": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.7.0.tgz",
+			"integrity": "sha512-9GTl1nE8Mx1kTZ+7QyYatDyKsm34QcWRBFkY1iPvWC3X4Dona5s/tlLiQsx5WzVdZqiMBZNYT0buyw4/vbhnjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.7.0",
+				"@peculiar/asn1-x509": "^2.7.0",
+				"asn1js": "^3.0.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-pkcs9": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.7.0.tgz",
+			"integrity": "sha512-Bh7m+OuIaSEllPQcSd9OSp93F4ROWH7sbITWV8MI+8dwsjE5111/87VxiWVvYFKyww3vp39geLv9ENqhwWHcew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-cms": "^2.7.0",
+				"@peculiar/asn1-pfx": "^2.7.0",
+				"@peculiar/asn1-pkcs8": "^2.7.0",
+				"@peculiar/asn1-schema": "^2.7.0",
+				"@peculiar/asn1-x509": "^2.7.0",
+				"@peculiar/asn1-x509-attr": "^2.7.0",
+				"asn1js": "^3.0.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-rsa": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.7.0.tgz",
+			"integrity": "sha512-/qvENQrXyTZURjMqSeofHul0JJt2sNSzSwk36pl2olkHbaioMQgrASDZAlHXl0xUlnVbHj0uGgOrBMTb5x2aJQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.7.0",
+				"@peculiar/asn1-x509": "^2.7.0",
+				"asn1js": "^3.0.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-schema": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.7.0.tgz",
+			"integrity": "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/utils": "^2.0.2",
+				"asn1js": "^3.0.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-x509": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.7.0.tgz",
+			"integrity": "sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.7.0",
+				"@peculiar/utils": "^2.0.2",
+				"asn1js": "^3.0.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-x509-attr": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.7.0.tgz",
+			"integrity": "sha512-NS8e7SOgXipkzUPLF/sce7ukpMpWjhxYsH0n6Y+bHYo4TTxOb95Zv7hqwSuL212mj5YxovjdOKQOgH1As3E94w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.7.0",
+				"@peculiar/asn1-x509": "^2.7.0",
+				"asn1js": "^3.0.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/utils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+			"integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/x509": {
+			"version": "1.14.3",
+			"resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+			"integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-cms": "^2.6.0",
+				"@peculiar/asn1-csr": "^2.6.0",
+				"@peculiar/asn1-ecc": "^2.6.0",
+				"@peculiar/asn1-pkcs9": "^2.6.0",
+				"@peculiar/asn1-rsa": "^2.6.0",
+				"@peculiar/asn1-schema": "^2.6.0",
+				"@peculiar/asn1-x509": "^2.6.0",
+				"pvtsutils": "^1.3.6",
+				"reflect-metadata": "^0.2.2",
+				"tslib": "^2.8.1",
+				"tsyringe": "^4.10.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
 		"node_modules/@php-wasm/cli-util": {
-			"version": "3.1.29",
-			"resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.29.tgz",
-			"integrity": "sha512-saVEkjCQGsLBrg0MB6oHF5jZudLK0siKXiCMFkbe99DqRQSckE59PHWh7LJ2nrtTO7rayMqdMe09Pa+5EpSS6Q==",
+			"version": "3.1.30",
+			"resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.30.tgz",
+			"integrity": "sha512-1FdLaunVvVuFaMFrco1pt+q8lXOxCaHqN5m2cJFTf3MOWOV8avebjdTqPxJrUvPgFEatwkfBLgJYASfWcEkCEQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/util": "3.1.29",
+				"@php-wasm/util": "3.1.30",
 				"fast-xml-parser": "^5.5.1",
 				"jsonc-parser": "3.3.1"
 			},
@@ -5522,9 +6134,9 @@
 			}
 		},
 		"node_modules/@php-wasm/logger": {
-			"version": "3.1.29",
-			"resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.29.tgz",
-			"integrity": "sha512-UPm67EQYA4W487HsdSVBzU/QEieXw4MSGBXUmDepqGtn/CXq+1cbvfK/MfgbzDF/M/q7pg5qea0Eb11Guvs8Fg==",
+			"version": "3.1.30",
+			"resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.30.tgz",
+			"integrity": "sha512-Du0Ux1pSLmwE5pj2RZLbbmhFhDPhGpdnQ1cbliK9QhjyzybgCXDy1yudp9ZSAmAxOYglwEk9Z65isMZoCPRcoA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -5533,24 +6145,24 @@
 			}
 		},
 		"node_modules/@php-wasm/node": {
-			"version": "3.1.29",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.29.tgz",
-			"integrity": "sha512-qsjkAUAr9oUSnPtcILE5KZqQQBF62atEfSfkyqJb8Lf3RdIrorqnx4/GiBu8Qz+uDhQc4GvSUPg2en4wJ1PNpQ==",
+			"version": "3.1.30",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.30.tgz",
+			"integrity": "sha512-DhDew6Ar2bRi1whKiMvBTLLyx+4gR6tiPOjpTS9IEx58lFKMtzCzpjTDC3YA6QUzASbcpenBLw7JZVLLMjzsKg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/cli-util": "3.1.29",
-				"@php-wasm/logger": "3.1.29",
-				"@php-wasm/node-5-2": "3.1.29",
-				"@php-wasm/node-7-4": "3.1.29",
-				"@php-wasm/node-8-0": "3.1.29",
-				"@php-wasm/node-8-1": "3.1.29",
-				"@php-wasm/node-8-2": "3.1.29",
-				"@php-wasm/node-8-3": "3.1.29",
-				"@php-wasm/node-8-4": "3.1.29",
-				"@php-wasm/node-8-5": "3.1.29",
-				"@php-wasm/universal": "3.1.29",
-				"@php-wasm/util": "3.1.29",
+				"@php-wasm/cli-util": "3.1.30",
+				"@php-wasm/logger": "3.1.30",
+				"@php-wasm/node-5-2": "3.1.30",
+				"@php-wasm/node-7-4": "3.1.30",
+				"@php-wasm/node-8-0": "3.1.30",
+				"@php-wasm/node-8-1": "3.1.30",
+				"@php-wasm/node-8-2": "3.1.30",
+				"@php-wasm/node-8-3": "3.1.30",
+				"@php-wasm/node-8-4": "3.1.30",
+				"@php-wasm/node-8-5": "3.1.30",
+				"@php-wasm/universal": "3.1.30",
+				"@php-wasm/util": "3.1.30",
 				"fs-ext-extra-prebuilt": "2.2.7",
 				"wasm-feature-detect": "1.8.0",
 				"ws": "8.18.0"
@@ -5561,13 +6173,13 @@
 			}
 		},
 		"node_modules/@php-wasm/node-5-2": {
-			"version": "3.1.29",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-5-2/-/node-5-2-3.1.29.tgz",
-			"integrity": "sha512-6giRuYnQkGrpA20sqteq/lHlZrpBw46iIqxDN4+sV5sMODMdIpr6xzSRh3t80xjGGNOkHH4D+FxqwyCvM608Lw==",
+			"version": "3.1.30",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-5-2/-/node-5-2-3.1.30.tgz",
+			"integrity": "sha512-C0xhz0VqQ8y0ZOIWGMtFR+HjZL5wBZysPWTPWOyi1oXU1i9vYDb+bMER0Pza/60lLQBAFZkn5tc2/TPPlTuRdA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.29",
+				"@php-wasm/universal": "3.1.30",
 				"wasm-feature-detect": "1.8.0"
 			},
 			"engines": {
@@ -5576,13 +6188,13 @@
 			}
 		},
 		"node_modules/@php-wasm/node-7-4": {
-			"version": "3.1.29",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.29.tgz",
-			"integrity": "sha512-Y17c4bbDyV7M8OkG/dJ7/y36fgHcE9xMXXGHVQRNpFJn0CIJP1unWJWBpkzLTZtliKJv1jvcfmUc+xkGSL1RdQ==",
+			"version": "3.1.30",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.30.tgz",
+			"integrity": "sha512-u7TsczOl3alDDZGuwIT16nAKVdtp9g2WWxZRVI3Mn4Di/x8NKCj1OOj5hrWxjsUQv/8f5hoqYU8tI/77rlC0Sw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.29",
+				"@php-wasm/universal": "3.1.30",
 				"wasm-feature-detect": "1.8.0"
 			},
 			"engines": {
@@ -5591,13 +6203,13 @@
 			}
 		},
 		"node_modules/@php-wasm/node-8-0": {
-			"version": "3.1.29",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.29.tgz",
-			"integrity": "sha512-lzVN75ktC36hRqPkvJB6dXoE2h3PQ9hQGvYgus9p0uqEeUaPq7A7gYn6YSLu1iYBvoIvMxdTS7CzV/6e/PG5TQ==",
+			"version": "3.1.30",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.30.tgz",
+			"integrity": "sha512-cNp/NIMb60WwNgqen0FPnDvilDgp5oVJ43cCAV5jPsDTFgsVz5BhI3R8leWf4c2+iUiOeyx2RINVLIHrQto5zA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.29",
+				"@php-wasm/universal": "3.1.30",
 				"wasm-feature-detect": "1.8.0"
 			},
 			"engines": {
@@ -5606,13 +6218,13 @@
 			}
 		},
 		"node_modules/@php-wasm/node-8-1": {
-			"version": "3.1.29",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.29.tgz",
-			"integrity": "sha512-ZFJzqcFYJ7KEDIj0LStvFri2yYQpxJ9xIBP7dYPP9h1lgVYybRnRFTp4TUwKb5j3FRkcSkSB0oZc0BVpT+8LRg==",
+			"version": "3.1.30",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.30.tgz",
+			"integrity": "sha512-IeGFtFFX+if3zhArla4IibQRn0hNaEMGw9bWn/irFQxg9gXkgj8zX1g7Own5DQH09dhu8rmNw/v1qhfXUB284A==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.29",
+				"@php-wasm/universal": "3.1.30",
 				"wasm-feature-detect": "1.8.0"
 			},
 			"engines": {
@@ -5621,13 +6233,13 @@
 			}
 		},
 		"node_modules/@php-wasm/node-8-2": {
-			"version": "3.1.29",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.29.tgz",
-			"integrity": "sha512-ly62jp97xjTDZYGzoEbJt1tEkZktrKd5RTy1B8awzgPepxb8+F0d7BaIGlIK4EnxI2S/mTw2m5sDhbzAibycqQ==",
+			"version": "3.1.30",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.30.tgz",
+			"integrity": "sha512-pV0e7QWnvR64FxD7WkU2aIEuYeUjqzoBsshH3xUImA4oecyZXPM1LWEBZ7AtCIASWabBb51v7OXomUqbsw2Wgg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.29",
+				"@php-wasm/universal": "3.1.30",
 				"wasm-feature-detect": "1.8.0"
 			},
 			"engines": {
@@ -5636,13 +6248,13 @@
 			}
 		},
 		"node_modules/@php-wasm/node-8-3": {
-			"version": "3.1.29",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.29.tgz",
-			"integrity": "sha512-pKV0MoXNvXFEs5mZ/oCPUDNxCtSxIGjGov89fohyjCPUjTmBQUXkkDMsneCgipUubc/Ysbm/hVPWB+VuhWElPg==",
+			"version": "3.1.30",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.30.tgz",
+			"integrity": "sha512-9Id8wgic1KtcLbtOiqQQ2IeeryNf/QkY154vrS3V994cFh9GP0wNcO5TmakjVmIxvDv4W6PtlZv7Yq5HWpkKEw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.29",
+				"@php-wasm/universal": "3.1.30",
 				"wasm-feature-detect": "1.8.0"
 			},
 			"engines": {
@@ -5651,13 +6263,13 @@
 			}
 		},
 		"node_modules/@php-wasm/node-8-4": {
-			"version": "3.1.29",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.29.tgz",
-			"integrity": "sha512-HXJ8GzqNaYPjN/V4RC77lCJUd7YYRlQtV7JTdKhRdq56e8CezbaFu25mUtpJGeXaJ0CNTu7e0SxQ6lGTq2spIg==",
+			"version": "3.1.30",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.30.tgz",
+			"integrity": "sha512-yxZA3kJ+dsRmzCjvL57IwtZaCAPZPA/Jak0E0/Gbjk3pk/OFtY3oehDdCP9wAlWdA22s/k6bjP63D7iNyQGJiw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.29",
+				"@php-wasm/universal": "3.1.30",
 				"wasm-feature-detect": "1.8.0"
 			},
 			"engines": {
@@ -5666,13 +6278,13 @@
 			}
 		},
 		"node_modules/@php-wasm/node-8-5": {
-			"version": "3.1.29",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.29.tgz",
-			"integrity": "sha512-5dQqlD4GgPzH8cAehShyU7+QgVr02ChvRIu1COhWhGDsv/a5tzAj8rXpnB79Xn6+BUeVAXJ4THx9kMttsuLjhA==",
+			"version": "3.1.30",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.30.tgz",
+			"integrity": "sha512-fzQxqRObRNrNKuNSe2Aew5Z6j6/ZvNYJC1WeAXP/yLH1hbIna88E0SHQzfLXrIZuTfGYahYcINN2HcqSflThdQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.29",
+				"@php-wasm/universal": "3.1.30",
 				"wasm-feature-detect": "1.8.0"
 			},
 			"engines": {
@@ -5681,13 +6293,13 @@
 			}
 		},
 		"node_modules/@php-wasm/progress": {
-			"version": "3.1.29",
-			"resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.29.tgz",
-			"integrity": "sha512-I2Outwb6VzdzNLYzvr+3vrF7DnkbD+TNS9Hefo/3rcp8KWtaA8OBa+3SvZ6K/nTDAk3KphpHMlm2F4DQNkC+ug==",
+			"version": "3.1.30",
+			"resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.30.tgz",
+			"integrity": "sha512-7ulbtY1A2deHyPd8GlLkgN776pBfEt35iiUbFxorHY9Oz3tBjpZSqEqRXzH3SHImp5POVvT9PSmAlAFSYdAKyA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/logger": "3.1.29"
+				"@php-wasm/logger": "3.1.30"
 			},
 			"engines": {
 				"node": ">=20.10.0",
@@ -5695,9 +6307,9 @@
 			}
 		},
 		"node_modules/@php-wasm/scopes": {
-			"version": "3.1.29",
-			"resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.29.tgz",
-			"integrity": "sha512-5+An/zjhjfKKFDNgzQracspFm5x0H/IZ/NWhte9+QbdSIkXPcFZN6ZpuxSRU0d5H3J8EwN52/QNcY/7+1IwZDw==",
+			"version": "3.1.30",
+			"resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.30.tgz",
+			"integrity": "sha512-EmYkNEcoK1R2dOqGloh3RNfAiMLSRzDOGyBfWWeKteooxzxsxAiwHPxjgVlGqb5zAWQVoB9FEJSIUgGRjjQSPg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -5706,26 +6318,26 @@
 			}
 		},
 		"node_modules/@php-wasm/stream-compression": {
-			"version": "3.1.29",
-			"resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.29.tgz",
-			"integrity": "sha512-oAgV8WkbWJ6j3ZhWoRjJivyuYdTKodtLjExEQ49VTGRVvyQgjNKz3CIO39Pnnt5KrYFmj1+YnEPjzNAfRMUjUQ==",
+			"version": "3.1.30",
+			"resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.30.tgz",
+			"integrity": "sha512-yJ+4GvXRjO/bcZlBDsCUijYByff3aipdyi018MzqbTENF68nK6WOnSm+bBhDpvpZ4ZZ2yTTgDzpwdw5PJAVS0A==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/util": "3.1.29"
+				"@php-wasm/util": "3.1.30"
 			}
 		},
 		"node_modules/@php-wasm/universal": {
-			"version": "3.1.29",
-			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.29.tgz",
-			"integrity": "sha512-RsvMUNh8YUE+ub5FjEYzK/NkUDe+qFDarhnHs+Xa6VISC6IT/zfbzzAouxq55zfTBBq3OoAAfNIr/5hvUL69BQ==",
+			"version": "3.1.30",
+			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.30.tgz",
+			"integrity": "sha512-6P5OrBEjE24X4IcDDSD6mJSdQuB94eQ8q5Wp3YzHjO7yjSd4TOqWmlrFZTjbGJfz7fH7ZbR8g5UmlZ8e/AZPEg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/logger": "3.1.29",
-				"@php-wasm/progress": "3.1.29",
-				"@php-wasm/stream-compression": "3.1.29",
-				"@php-wasm/util": "3.1.29",
+				"@php-wasm/logger": "3.1.30",
+				"@php-wasm/progress": "3.1.30",
+				"@php-wasm/stream-compression": "3.1.30",
+				"@php-wasm/util": "3.1.30",
 				"ini": "4.1.2"
 			},
 			"engines": {
@@ -5734,9 +6346,9 @@
 			}
 		},
 		"node_modules/@php-wasm/util": {
-			"version": "3.1.29",
-			"resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.29.tgz",
-			"integrity": "sha512-k7ZIbibADTK0B/hsgFZ4RDPnIKZ1p37c2qAjZts9nl5C4zCzGO9giLA16wBV/+78vL8hkLkNQSQpkQlBZVxn3g==",
+			"version": "3.1.30",
+			"resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.30.tgz",
+			"integrity": "sha512-Ak2vRZIviWn3KrBcLNhhAWN9qdhRCNdtvZJDBjOHm4yajqYraSFl9tDqyu6vz2KJgcsVfsZpS+BOR9hLvR2nMw==",
 			"dev": true,
 			"engines": {
 				"node": ">=20.10.0",
@@ -5744,14 +6356,14 @@
 			}
 		},
 		"node_modules/@php-wasm/web-service-worker": {
-			"version": "3.1.29",
-			"resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.29.tgz",
-			"integrity": "sha512-cHwCofTpLNKt8VedLFOj6F+icRPoEzmHSzcK/lUpoiyfRjTTAgrb5vh+3HGG+JH4kYMUsrVoYUrOrsgBey2p8w==",
+			"version": "3.1.30",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.30.tgz",
+			"integrity": "sha512-IPnRTr1TPU/m7rw20ZwOntXAuykWahybakYMjzKQjSSOA7MV3dSbbEXADAw03SKGSLivzTehXXveY4/zXSk0lQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/scopes": "3.1.29",
-				"@php-wasm/universal": "3.1.29"
+				"@php-wasm/scopes": "3.1.30",
+				"@php-wasm/universal": "3.1.30"
 			},
 			"engines": {
 				"node": ">=20.10.0",
@@ -5759,14 +6371,14 @@
 			}
 		},
 		"node_modules/@php-wasm/xdebug-bridge": {
-			"version": "3.1.29",
-			"resolved": "https://registry.npmjs.org/@php-wasm/xdebug-bridge/-/xdebug-bridge-3.1.29.tgz",
-			"integrity": "sha512-+mNZAunAPuV2WAjexp+e6HxLQxcphJZ6ent767CuIrj466gzvhYLrYVZwgIUJxR66QCrvfX2wIpEKMbvS0ElGg==",
+			"version": "3.1.30",
+			"resolved": "https://registry.npmjs.org/@php-wasm/xdebug-bridge/-/xdebug-bridge-3.1.30.tgz",
+			"integrity": "sha512-f2p8kFpdSCLQrF3ly8UdZqsP7MqKzN3nYoo/7T3AAhgwf7TIqcWDSv1J9dyHbKVQHG3jvHx5E9dPD3KT5iObZg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/logger": "3.1.29",
-				"@php-wasm/universal": "3.1.29",
+				"@php-wasm/logger": "3.1.30",
+				"@php-wasm/universal": "3.1.30",
 				"ws": "8.18.0",
 				"xml2js": "0.6.2",
 				"yargs": "17.7.2"
@@ -5804,14 +6416,14 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-			"integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+			"integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"playwright": "1.59.1"
+				"playwright": "1.60.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -6633,19 +7245,6 @@
 			}
 		},
 		"node_modules/@types/express-serve-static-core": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
-			"integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*",
-				"@types/qs": "*",
-				"@types/range-parser": "*",
-				"@types/send": "*"
-			}
-		},
-		"node_modules/@types/express/node_modules/@types/express-serve-static-core": {
 			"version": "4.19.8",
 			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
 			"integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
@@ -6798,23 +7397,13 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "20.19.40",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.40.tgz",
-			"integrity": "sha512-xxx6M2IpSTnnKcR0cMvIiohkiCx20/oRPtWGbenFygKCGl3zqUzdNjQ/1V4solq1LU+dgv0nQzeGOuqkqZGg0Q==",
+			"version": "20.19.41",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+			"integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.21.0"
-			}
-		},
-		"node_modules/@types/node-forge": {
-			"version": "1.3.14",
-			"resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
-			"integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
 			}
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -6906,9 +7495,9 @@
 			}
 		},
 		"node_modules/@types/retry": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"version": "0.12.2",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+			"integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -7035,17 +7624,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
-			"integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
+			"integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.59.2",
-				"@typescript-eslint/type-utils": "8.59.2",
-				"@typescript-eslint/utils": "8.59.2",
-				"@typescript-eslint/visitor-keys": "8.59.2",
+				"@typescript-eslint/scope-manager": "8.59.3",
+				"@typescript-eslint/type-utils": "8.59.3",
+				"@typescript-eslint/utils": "8.59.3",
+				"@typescript-eslint/visitor-keys": "8.59.3",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.5.0"
@@ -7058,22 +7647,22 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.59.2",
+				"@typescript-eslint/parser": "^8.59.3",
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
-			"integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
+			"integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.59.2",
-				"@typescript-eslint/types": "8.59.2",
-				"@typescript-eslint/typescript-estree": "8.59.2",
-				"@typescript-eslint/visitor-keys": "8.59.2",
+				"@typescript-eslint/scope-manager": "8.59.3",
+				"@typescript-eslint/types": "8.59.3",
+				"@typescript-eslint/typescript-estree": "8.59.3",
+				"@typescript-eslint/visitor-keys": "8.59.3",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -7089,14 +7678,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
-			"integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
+			"integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.59.2",
-				"@typescript-eslint/types": "^8.59.2",
+				"@typescript-eslint/tsconfig-utils": "^8.59.3",
+				"@typescript-eslint/types": "^8.59.3",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -7111,14 +7700,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
-			"integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
+			"integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.2",
-				"@typescript-eslint/visitor-keys": "8.59.2"
+				"@typescript-eslint/types": "8.59.3",
+				"@typescript-eslint/visitor-keys": "8.59.3"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7129,9 +7718,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
-			"integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
+			"integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -7146,15 +7735,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
-			"integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
+			"integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.2",
-				"@typescript-eslint/typescript-estree": "8.59.2",
-				"@typescript-eslint/utils": "8.59.2",
+				"@typescript-eslint/types": "8.59.3",
+				"@typescript-eslint/typescript-estree": "8.59.3",
+				"@typescript-eslint/utils": "8.59.3",
 				"debug": "^4.4.3",
 				"ts-api-utils": "^2.5.0"
 			},
@@ -7171,9 +7760,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
-			"integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
+			"integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -7185,16 +7774,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
-			"integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
+			"integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.59.2",
-				"@typescript-eslint/tsconfig-utils": "8.59.2",
-				"@typescript-eslint/types": "8.59.2",
-				"@typescript-eslint/visitor-keys": "8.59.2",
+				"@typescript-eslint/project-service": "8.59.3",
+				"@typescript-eslint/tsconfig-utils": "8.59.3",
+				"@typescript-eslint/types": "8.59.3",
+				"@typescript-eslint/visitor-keys": "8.59.3",
 				"debug": "^4.4.3",
 				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
@@ -7265,16 +7854,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
-			"integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
+			"integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.59.2",
-				"@typescript-eslint/types": "8.59.2",
-				"@typescript-eslint/typescript-estree": "8.59.2"
+				"@typescript-eslint/scope-manager": "8.59.3",
+				"@typescript-eslint/types": "8.59.3",
+				"@typescript-eslint/typescript-estree": "8.59.3"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7289,13 +7878,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
-			"integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
+			"integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.2",
+				"@typescript-eslint/types": "8.59.3",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
@@ -8761,20 +9350,20 @@
 			}
 		},
 		"node_modules/@wp-playground/blueprints": {
-			"version": "3.1.29",
-			"resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.29.tgz",
-			"integrity": "sha512-ueVyFznR5fvzKxHpve1MZX8FA6SOJQqnrf/5N+tqJ48D5SBUd0OR+clwrKO2duJlnouC1I0JX8z8TQCbooY2SQ==",
+			"version": "3.1.30",
+			"resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.30.tgz",
+			"integrity": "sha512-E3oyFaD2P9OrYSK7DLtL+kyk0OHtjePhBLmbHUUgXO4Jxnk2yCzaVYqJNHZmFGMyWMUfBPtbapto2SkRSoiN7w==",
 			"dev": true,
 			"dependencies": {
-				"@php-wasm/logger": "3.1.29",
-				"@php-wasm/progress": "3.1.29",
-				"@php-wasm/stream-compression": "3.1.29",
-				"@php-wasm/universal": "3.1.29",
-				"@php-wasm/util": "3.1.29",
-				"@php-wasm/web-service-worker": "3.1.29",
-				"@wp-playground/common": "3.1.29",
-				"@wp-playground/storage": "3.1.29",
-				"@wp-playground/wordpress": "3.1.29",
+				"@php-wasm/logger": "3.1.30",
+				"@php-wasm/progress": "3.1.30",
+				"@php-wasm/stream-compression": "3.1.30",
+				"@php-wasm/universal": "3.1.30",
+				"@php-wasm/util": "3.1.30",
+				"@php-wasm/web-service-worker": "3.1.30",
+				"@wp-playground/common": "3.1.30",
+				"@wp-playground/storage": "3.1.30",
+				"@wp-playground/wordpress": "3.1.30",
 				"ajv": "8.12.0"
 			},
 			"engines": {
@@ -8783,24 +9372,24 @@
 			}
 		},
 		"node_modules/@wp-playground/cli": {
-			"version": "3.1.29",
-			"resolved": "https://registry.npmjs.org/@wp-playground/cli/-/cli-3.1.29.tgz",
-			"integrity": "sha512-VLtuCV7BkB54nZJjbuBJrOAfoc9/F27+imVym7DoIuKb4xv3i+7tMAVEOQUTsz3c13uHzp9xtO5lwV9T1AvS9g==",
+			"version": "3.1.30",
+			"resolved": "https://registry.npmjs.org/@wp-playground/cli/-/cli-3.1.30.tgz",
+			"integrity": "sha512-HPamsysVxiGmaIE4kJhwwrSr+tUYHsbBairqhzgQFdKhQxIoZ684ZA+A5IPkxY9D8zF1JsFWFJGtqKQMTnNabg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/cli-util": "3.1.29",
-				"@php-wasm/logger": "3.1.29",
-				"@php-wasm/node": "3.1.29",
-				"@php-wasm/progress": "3.1.29",
-				"@php-wasm/universal": "3.1.29",
-				"@php-wasm/util": "3.1.29",
-				"@php-wasm/xdebug-bridge": "3.1.29",
-				"@wp-playground/blueprints": "3.1.29",
-				"@wp-playground/common": "3.1.29",
-				"@wp-playground/storage": "3.1.29",
-				"@wp-playground/tools": "3.1.29",
-				"@wp-playground/wordpress": "3.1.29",
+				"@php-wasm/cli-util": "3.1.30",
+				"@php-wasm/logger": "3.1.30",
+				"@php-wasm/node": "3.1.30",
+				"@php-wasm/progress": "3.1.30",
+				"@php-wasm/universal": "3.1.30",
+				"@php-wasm/util": "3.1.30",
+				"@php-wasm/xdebug-bridge": "3.1.30",
+				"@wp-playground/blueprints": "3.1.30",
+				"@wp-playground/common": "3.1.30",
+				"@wp-playground/storage": "3.1.30",
+				"@wp-playground/tools": "3.1.30",
+				"@wp-playground/wordpress": "3.1.30",
 				"express": "4.22.0",
 				"fs-extra": "11.1.1",
 				"tmp-promise": "3.0.3",
@@ -8812,14 +9401,14 @@
 			}
 		},
 		"node_modules/@wp-playground/common": {
-			"version": "3.1.29",
-			"resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.29.tgz",
-			"integrity": "sha512-tmzhEFaUaftl1Ml0jHESR1TxCGnbl1ab02LJn6RkxOVp3mmg90fyM//Y1oW6zXP8nwx052rj2G9QkkzhtO/Xbg==",
+			"version": "3.1.30",
+			"resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.30.tgz",
+			"integrity": "sha512-tyqGMP+jyYy8pNhyg3G52y1v0I5q7z5rRopei8lp9Bd7OKCycXH52OzfMjQAy8OSAb2JPYbk0Tk3FEeqD7FYMg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.29",
-				"@php-wasm/util": "3.1.29"
+				"@php-wasm/universal": "3.1.30",
+				"@php-wasm/util": "3.1.30"
 			},
 			"engines": {
 				"node": ">=20.10.0",
@@ -8827,15 +9416,15 @@
 			}
 		},
 		"node_modules/@wp-playground/storage": {
-			"version": "3.1.29",
-			"resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.29.tgz",
-			"integrity": "sha512-Xlpi8J+12Bv2TJeipbMCdf2uuYOiXVhqhM6ID4dJoh1FlFjXTtmSEqH9kel5RuPoy9W1oiTXHO5I1cZRWqZUJQ==",
+			"version": "3.1.30",
+			"resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.30.tgz",
+			"integrity": "sha512-ePj9/BshpYpNdPrV8QkT4nEqLN/XUcJYwqhWOEG+6EJac84WJdOfBxkQoJow/N+HC2RnvEPvclvurzXsCWZI8g==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/stream-compression": "3.1.29",
-				"@php-wasm/universal": "3.1.29",
-				"@php-wasm/util": "3.1.29",
+				"@php-wasm/stream-compression": "3.1.30",
+				"@php-wasm/universal": "3.1.30",
+				"@php-wasm/util": "3.1.30",
 				"@zip.js/zip.js": "2.7.57",
 				"isomorphic-git": "1.37.6",
 				"octokit": "3.1.2",
@@ -8843,13 +9432,13 @@
 			}
 		},
 		"node_modules/@wp-playground/tools": {
-			"version": "3.1.29",
-			"resolved": "https://registry.npmjs.org/@wp-playground/tools/-/tools-3.1.29.tgz",
-			"integrity": "sha512-Qb7Lf6c053rms+gEyb1/p+8FKpn8LXGys5Ef+Ty74lPe2sfnH8FoS+ux7M2Rqn+9R+IrOxuV8F66UEP+yYHyLg==",
+			"version": "3.1.30",
+			"resolved": "https://registry.npmjs.org/@wp-playground/tools/-/tools-3.1.30.tgz",
+			"integrity": "sha512-YQOA/MoFReEjp/sviuw5z2HNinQZns8FKF3dR/uFVVyqHILPU692y4EpAdsej3wd9ODjsl7hJ1lZ3oQmR7byfQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wp-playground/blueprints": "3.1.29"
+				"@wp-playground/blueprints": "3.1.30"
 			},
 			"engines": {
 				"node": ">=20.10.0",
@@ -8857,16 +9446,16 @@
 			}
 		},
 		"node_modules/@wp-playground/wordpress": {
-			"version": "3.1.29",
-			"resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.29.tgz",
-			"integrity": "sha512-JZ7WAEJjphSlZbjKgQzaiRKg/1cacoTv5GGZi1ocXIjShGRea9kidPnxtMIJBJRcJzN8pqKxu6EVc9X8UDReBQ==",
+			"version": "3.1.30",
+			"resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.30.tgz",
+			"integrity": "sha512-KLjJn6+YQ7IcG3+0/1F0/IyxRM4bZyqdw3v7R2C2Cwu1T48syU1wQTqPp3nfB5JAx9qLK5Wcp1KlCw373a8x9Q==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/logger": "3.1.29",
-				"@php-wasm/universal": "3.1.29",
-				"@php-wasm/util": "3.1.29",
-				"@wp-playground/common": "3.1.29"
+				"@php-wasm/logger": "3.1.30",
+				"@php-wasm/universal": "3.1.30",
+				"@php-wasm/util": "3.1.30",
+				"@wp-playground/common": "3.1.30"
 			},
 			"engines": {
 				"node": ">=20.10.0",
@@ -9405,6 +9994,21 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/asn1js": {
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+			"integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"pvtsutils": "^1.3.6",
+				"pvutils": "^1.1.5",
+				"tslib": "^2.8.1"
+			},
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/ast-types": {
@@ -10131,6 +10735,22 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/bundle-name": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+			"integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"run-applescript": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/bytes": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -10139,6 +10759,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/bytestreamjs": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+			"integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/cacheable": {
@@ -11631,17 +12261,34 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/default-gateway": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
-			"integrity": "sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==",
+		"node_modules/default-browser": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+			"integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
 			"dev": true,
-			"license": "BSD-2-Clause",
+			"license": "MIT",
 			"dependencies": {
-				"execa": "^5.0.0"
+				"bundle-name": "^4.1.0",
+				"default-browser-id": "^5.0.0"
 			},
 			"engines": {
-				"node": ">= 10"
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-browser-id": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+			"integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/defaults": {
@@ -12073,9 +12720,9 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.21.2",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.2.tgz",
-			"integrity": "sha512-xe9vQb5kReirPUxgQrXA3ihgbCqssmTiM7cOZ+Gzu+VeGWgpV98lLZvp0dl4yriyAePcewxGUs9UpKD8PET9KQ==",
+			"version": "5.21.3",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.3.tgz",
+			"integrity": "sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -13908,13 +14555,6 @@
 				"node": ">=14.14"
 			}
 		},
-		"node_modules/fs-monkey": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.1.0.tgz",
-			"integrity": "sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw==",
-			"dev": true,
-			"license": "Unlicense"
-		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -14178,6 +14818,23 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/glob-to-regex.js": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz",
+			"integrity": "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
 			}
 		},
 		"node_modules/glob-to-regexp": {
@@ -14775,6 +15432,16 @@
 				"node": ">=10.17.0"
 			}
 		},
+		"node_modules/hyperdyperid": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+			"integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.18"
+			}
+		},
 		"node_modules/iconv-lite": {
 			"version": "0.7.2",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -15343,6 +16010,41 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-inside-container": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+			"integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-docker": "^3.0.0"
+			},
+			"bin": {
+				"is-inside-container": "cli.js"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-inside-container/node_modules/is-docker": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+			"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-interactive": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
@@ -15377,6 +16079,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-network-error": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
+			"integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-number": {
@@ -17126,9 +17841,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/lighthouse/node_modules/@puppeteer/browsers": {
-			"version": "2.13.1",
-			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.1.tgz",
-			"integrity": "sha512-zmS4RTK9fbrc++WlAJhxYbfz3IjDeOmkK/CwwbLmk7ydfS9e2CiEeRJHEPvjDVElO/bwXbidwGA37Bsm6LzCnQ==",
+			"version": "2.13.2",
+			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.2.tgz",
+			"integrity": "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -17169,13 +17884,13 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core": {
-			"version": "24.43.0",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.0.tgz",
-			"integrity": "sha512-cCRNXsUlhyPoKDz6+TiSpfZpRS3mD6Y1YFKhkdr6ik6TMfuJb7fAtXq9ThUFc4sphxObDk3BuAvdxc1Y6YOnqQ==",
+			"version": "24.43.1",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.1.tgz",
+			"integrity": "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@puppeteer/browsers": "2.13.1",
+				"@puppeteer/browsers": "2.13.2",
 				"chromium-bidi": "14.0.0",
 				"debug": "^4.4.3",
 				"devtools-protocol": "0.0.1608973",
@@ -17705,19 +18420,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/markdownlint-cli/node_modules/minimatch": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
-			"integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/markdownlint-rule-helpers": {
 			"version": "0.16.0",
 			"resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.16.0.tgz",
@@ -17778,16 +18480,33 @@
 			}
 		},
 		"node_modules/memfs": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
-			"integrity": "sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==",
+			"version": "4.57.2",
+			"resolved": "https://registry.npmjs.org/memfs/-/memfs-4.57.2.tgz",
+			"integrity": "sha512-2nWzSsJzrukurSDna4Z0WywuScK4Id3tSKejgu74u8KCdW4uNrseKRSIDg75C6Yw5ZRqBe0F0EtMNlTbUq8bAQ==",
 			"dev": true,
-			"license": "Unlicense",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"fs-monkey": "^1.0.4"
+				"@jsonjoy.com/fs-core": "4.57.2",
+				"@jsonjoy.com/fs-fsa": "4.57.2",
+				"@jsonjoy.com/fs-node": "4.57.2",
+				"@jsonjoy.com/fs-node-builtins": "4.57.2",
+				"@jsonjoy.com/fs-node-to-fsa": "4.57.2",
+				"@jsonjoy.com/fs-node-utils": "4.57.2",
+				"@jsonjoy.com/fs-print": "4.57.2",
+				"@jsonjoy.com/fs-snapshot": "4.57.2",
+				"@jsonjoy.com/json-pack": "^1.11.0",
+				"@jsonjoy.com/util": "^1.9.0",
+				"glob-to-regex.js": "^1.0.1",
+				"thingies": "^2.5.0",
+				"tree-dump": "^1.0.3",
+				"tslib": "^2.0.0"
 			},
-			"engines": {
-				"node": ">= 4.0.0"
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
 			}
 		},
 		"node_modules/memize": {
@@ -18296,16 +19015,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/node-forge": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
-			"integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
-			"dev": true,
-			"license": "(BSD-3-Clause OR GPL-2.0)",
-			"engines": {
-				"node": ">= 6.13.0"
 			}
 		},
 		"node_modules/node-int64": {
@@ -19040,17 +19749,21 @@
 			}
 		},
 		"node_modules/p-retry": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.1.tgz",
+			"integrity": "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/retry": "0.12.0",
+				"@types/retry": "0.12.2",
+				"is-network-error": "^1.0.0",
 				"retry": "^0.13.1"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=16.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-try": {
@@ -19524,15 +20237,33 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/pkijs": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+			"integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@noble/hashes": "1.4.0",
+				"asn1js": "^3.0.6",
+				"bytestreamjs": "^2.0.1",
+				"pvtsutils": "^1.3.6",
+				"pvutils": "^1.1.3",
+				"tslib": "^2.8.1"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
 		"node_modules/playwright": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-			"integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+			"integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"playwright-core": "1.59.1"
+				"playwright-core": "1.60.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -19545,9 +20276,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-			"integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+			"integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
@@ -20609,6 +21340,26 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/pvtsutils": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+			"integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/pvutils": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+			"integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
 		"node_modules/qified": {
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/qified/-/qified-0.10.1.tgz",
@@ -20677,16 +21428,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/randombytes": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "^5.1.0"
 			}
 		},
 		"node_modules/range-parser": {
@@ -20955,6 +21696,13 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/reflect-metadata": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+			"integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+			"dev": true,
+			"license": "Apache-2.0"
 		},
 		"node_modules/reflect.getprototypeof": {
 			"version": "1.0.10",
@@ -21361,6 +22109,19 @@
 				"node": ">=12.0.0"
 			}
 		},
+		"node_modules/run-applescript": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+			"integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/run-con": {
 			"version": "1.2.12",
 			"resolved": "https://registry.npmjs.org/run-con/-/run-con-1.2.12.tgz",
@@ -21641,17 +22402,17 @@
 			"license": "MIT"
 		},
 		"node_modules/selfsigned": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
-			"integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-5.5.0.tgz",
+			"integrity": "sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/node-forge": "^1.3.0",
-				"node-forge": "^1"
+				"@peculiar/x509": "^1.14.2",
+				"pkijs": "^3.3.3"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
 			}
 		},
 		"node_modules/semver": {
@@ -21732,13 +22493,13 @@
 			}
 		},
 		"node_modules/serialize-javascript": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+			"integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
-			"dependencies": {
-				"randombytes": "^2.1.0"
+			"engines": {
+				"node": ">=20.0.0"
 			}
 		},
 		"node_modules/serve-index": {
@@ -23692,6 +24453,23 @@
 				}
 			}
 		},
+		"node_modules/thingies": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/thingies/-/thingies-2.6.0.tgz",
+			"integrity": "sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "^2"
+			}
+		},
 		"node_modules/third-party-web": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/third-party-web/-/third-party-web-0.27.0.tgz",
@@ -23906,6 +24684,23 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/tree-dump": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.1.0.tgz",
+			"integrity": "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
 		"node_modules/tree-kill": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -24002,6 +24797,26 @@
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
+			"license": "0BSD"
+		},
+		"node_modules/tsyringe": {
+			"version": "4.10.0",
+			"resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+			"integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^1.9.3"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/tsyringe/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"dev": true,
 			"license": "0BSD"
 		},
@@ -24163,16 +24978,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.2.tgz",
-			"integrity": "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.3.tgz",
+			"integrity": "sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.59.2",
-				"@typescript-eslint/parser": "8.59.2",
-				"@typescript-eslint/typescript-estree": "8.59.2",
-				"@typescript-eslint/utils": "8.59.2"
+				"@typescript-eslint/eslint-plugin": "8.59.3",
+				"@typescript-eslint/parser": "8.59.3",
+				"@typescript-eslint/typescript-estree": "8.59.3",
+				"@typescript-eslint/utils": "8.59.3"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -24846,79 +25661,110 @@
 			}
 		},
 		"node_modules/webpack-dev-middleware": {
-			"version": "5.3.4",
-			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
-			"integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.5.tgz",
+			"integrity": "sha512-uxQ6YqGdE4hgDKNf7hUiPXOdtkXvBJXrfEGYSx7P7LC8hnUYGK70X6xQXUvXeNyBDDcsiQXpG2m3G9vxowaEuA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"colorette": "^2.0.10",
-				"memfs": "^3.4.3",
-				"mime-types": "^2.1.31",
+				"memfs": "^4.43.1",
+				"mime-types": "^3.0.1",
+				"on-finished": "^2.4.1",
 				"range-parser": "^1.2.1",
 				"schema-utils": "^4.0.0"
 			},
 			"engines": {
-				"node": ">= 12.13.0"
+				"node": ">= 18.12.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"webpack": "^4.0.0 || ^5.0.0"
+				"webpack": "^5.0.0"
+			},
+			"peerDependenciesMeta": {
+				"webpack": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/webpack-dev-server": {
-			"version": "4.15.2",
-			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
-			"integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
+		"node_modules/webpack-dev-middleware/node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/webpack-dev-middleware/node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/bonjour": "^3.5.9",
-				"@types/connect-history-api-fallback": "^1.3.5",
-				"@types/express": "^4.17.13",
-				"@types/serve-index": "^1.9.1",
-				"@types/serve-static": "^1.13.10",
-				"@types/sockjs": "^0.3.33",
-				"@types/ws": "^8.5.5",
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/webpack-dev-server": {
+			"version": "5.2.4",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
+			"integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/bonjour": "^3.5.13",
+				"@types/connect-history-api-fallback": "^1.5.4",
+				"@types/express": "^4.17.25",
+				"@types/express-serve-static-core": "^4.17.21",
+				"@types/serve-index": "^1.9.4",
+				"@types/serve-static": "^1.15.5",
+				"@types/sockjs": "^0.3.36",
+				"@types/ws": "^8.5.10",
 				"ansi-html-community": "^0.0.8",
-				"bonjour-service": "^1.0.11",
-				"chokidar": "^3.5.3",
+				"bonjour-service": "^1.2.1",
+				"chokidar": "^3.6.0",
 				"colorette": "^2.0.10",
-				"compression": "^1.7.4",
+				"compression": "^1.8.1",
 				"connect-history-api-fallback": "^2.0.0",
-				"default-gateway": "^6.0.3",
-				"express": "^4.17.3",
+				"express": "^4.22.1",
 				"graceful-fs": "^4.2.6",
-				"html-entities": "^2.3.2",
-				"http-proxy-middleware": "^2.0.3",
-				"ipaddr.js": "^2.0.1",
-				"launch-editor": "^2.6.0",
-				"open": "^8.0.9",
-				"p-retry": "^4.5.0",
-				"rimraf": "^3.0.2",
-				"schema-utils": "^4.0.0",
-				"selfsigned": "^2.1.1",
+				"http-proxy-middleware": "^2.0.9",
+				"ipaddr.js": "^2.1.0",
+				"launch-editor": "^2.6.1",
+				"open": "^10.0.3",
+				"p-retry": "^6.2.0",
+				"schema-utils": "^4.2.0",
+				"selfsigned": "^5.5.0",
 				"serve-index": "^1.9.1",
 				"sockjs": "^0.3.24",
 				"spdy": "^4.0.2",
-				"webpack-dev-middleware": "^5.3.4",
-				"ws": "^8.13.0"
+				"webpack-dev-middleware": "^7.4.2",
+				"ws": "^8.18.0"
 			},
 			"bin": {
 				"webpack-dev-server": "bin/webpack-dev-server.js"
 			},
 			"engines": {
-				"node": ">= 12.13.0"
+				"node": ">= 18.12.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"webpack": "^4.37.0 || ^5.0.0"
+				"webpack": "^5.0.0"
 			},
 			"peerDependenciesMeta": {
 				"webpack": {
@@ -24954,6 +25800,76 @@
 				"fsevents": "~2.3.2"
 			}
 		},
+		"node_modules/webpack-dev-server/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/define-lazy-prop": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+			"integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/express": {
+			"version": "4.22.2",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+			"integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "~1.3.8",
+				"array-flatten": "1.1.1",
+				"body-parser": "~1.20.5",
+				"content-disposition": "~0.5.4",
+				"content-type": "~1.0.4",
+				"cookie": "~0.7.1",
+				"cookie-signature": "~1.0.6",
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"encodeurl": "~2.0.0",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"finalhandler": "~1.3.1",
+				"fresh": "~0.5.2",
+				"http-errors": "~2.0.0",
+				"merge-descriptors": "1.0.3",
+				"methods": "~1.1.2",
+				"on-finished": "~2.4.1",
+				"parseurl": "~1.3.3",
+				"path-to-regexp": "~0.1.12",
+				"proxy-addr": "~2.0.7",
+				"qs": "~6.15.1",
+				"range-parser": "~1.2.1",
+				"safe-buffer": "5.2.1",
+				"send": "~0.19.0",
+				"serve-static": "~1.16.2",
+				"setprototypeof": "1.2.0",
+				"statuses": "~2.0.1",
+				"type-is": "~1.6.18",
+				"utils-merge": "1.0.1",
+				"vary": "~1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/webpack-dev-server/node_modules/glob-parent": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -24977,6 +25893,48 @@
 				"node": ">= 10"
 			}
 		},
+		"node_modules/webpack-dev-server/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/webpack-dev-server/node_modules/open": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+			"integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"default-browser": "^5.2.1",
+				"define-lazy-prop": "^3.0.0",
+				"is-inside-container": "^1.0.0",
+				"wsl-utils": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/qs": {
+			"version": "6.15.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+			"integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/webpack-dev-server/node_modules/readdirp": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -24988,23 +25946,6 @@
 			},
 			"engines": {
 				"node": ">=8.10.0"
-			}
-		},
-		"node_modules/webpack-dev-server/node_modules/rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"deprecated": "Rimraf versions prior to v4 are no longer supported",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/webpack-merge": {
@@ -25389,6 +26330,38 @@
 				}
 			}
 		},
+		"node_modules/wsl-utils": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+			"integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-wsl": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/wsl-utils/node_modules/is-wsl": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+			"integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-inside-container": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/xdg-basedir": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
@@ -25487,9 +26460,9 @@
 			"license": "ISC"
 		},
 		"node_modules/yaml": {
-			"version": "2.8.4",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
-			"integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
 		"@wordpress/env": "^11.4.0",
 		"@wordpress/scripts": "^32.0.0"
 	},
+	"overrides": {
+		"minimatch@<3.1.5": "^3.1.5",
+		"serialize-javascript@<7.0.5": "^7.0.5",
+		"webpack-dev-server@<5.2.1": "^5.2.1"
+	},
 	"scripts": {
 		"wp-env": "wp-env",
 		"format": "wp-scripts format",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"@wordpress/scripts": "^32.0.0"
 	},
 	"overrides": {
-		"minimatch@<3.1.5": "^3.1.5",
+		"minimatch@>=3 <3.1.5": "^3.1.5",
 		"serialize-javascript@<7.0.5": "^7.0.5",
 		"webpack-dev-server@<5.2.1": "^5.2.1"
 	},


### PR DESCRIPTION
## Summary

Resolves the five open Dependabot alerts on `package-lock.json`. All are dev-only transitive dependencies brought in via `@wordpress/scripts` and `@wordpress/env`; the parent packages haven't yet shipped versions that pull in patched copies, so this uses `npm overrides` to force the fixed versions without downgrading `@wordpress/scripts` (which is what `npm audit fix --force` proposed).

| Package | Was | Now | Advisories |
|---|---|---|---|
| serialize-javascript | 6.0.2 | 7.0.5 | GHSA-5c6j-r48x-rmvq (high, RCE), GHSA-qj8w-gfj5-8c6v (medium, DoS) |
| minimatch (markdownlint-cli) | 3.0.8 | 3.1.5 | GHSA-7r86-cg39-jmmj (high, ReDoS) |
| webpack-dev-server | 4.15.2 | 5.2.4 | GHSA-9jgg-88mc-972h (medium), GHSA-4v9v-hfq4-rm2v (medium) |

Remaining `ajv` advisory was already auto-dismissed by Dependabot.

Note: this plugin is plain PHP — these npm packages exist only for the local dev environment (`wp-env`) and `npm run format`. No production code is shipped from `node_modules/`.

## Test plan

- [x] `npm install` succeeds with overrides applied
- [x] `npm audit` reports 0 open advisories matching the dependabot reports
- [x] `npm run format` still works (wp-scripts still functional)
- [ ] CI (`wpcs.yml`, `phpunit.yml`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)