### PR TITLE
Trunk-gate side-effect jobs and label-track failure issues

### DIFF
--- a/.github/workflows/update-tested-up-to.yml
+++ b/.github/workflows/update-tested-up-to.yml
@@ -112,12 +112,15 @@ jobs:
     notify-failure:
         name: Open issue when validation fails
         needs: [check, validate]
-        if: always() && needs.validate.result == 'failure'
+        # Only the canonical trunk run can open tracking issues, so manual
+        # workflow_dispatch from a feature branch can't pollute the issue
+        # tracker with branch-specific failures.
+        if: always() && needs.validate.result == 'failure' && github.ref == 'refs/heads/trunk'
         runs-on: ubuntu-latest
         permissions:
             issues: write
         steps:
-            - name: Open issue (deduped by title)
+            - name: Open (or reuse) tracking issue for this WordPress version
               shell: bash
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -127,29 +130,46 @@ jobs:
                   RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
               run: |
                   set -euo pipefail
+                  # Idempotently ensure the label exists — --force updates the
+                  # description/color if it does, creates it if it doesn't.
+                  gh label create tested-up-to-failure \
+                      --color B60205 \
+                      --description "Auto-opened by Update Tested up to workflow on validation failure" \
+                      --force >/dev/null
+
+                  # Dedupe by the label we own + the per-version title. The label
+                  # restricts the search to issues we created ourselves, so the
+                  # title check is reliable even though GitHub's search tokenizes
+                  # version strings. --paginate so dedupe still works in a repo
+                  # that has accumulated >100 open failure issues.
                   title="Validate failed against WordPress $VERSION"
-                  # Skip if an open issue already tracks this version's failure,
-                  # so daily retries don't spam.
-                  existing=$(gh issue list --state open --search "in:title \"$title\"" --json number --jq '.[0].number // empty')
+                  existing=$(gh api -X GET search/issues \
+                      -f q="repo:$GH_REPO is:issue is:open label:tested-up-to-failure" \
+                      -f per_page=100 --paginate \
+                      --jq ".items[] | select(.title == \"$title\") | .number" \
+                      | head -1)
                   if [ -n "$existing" ]; then
                       echo "Issue #$existing already tracks this failure; skipping."
                       exit 0
                   fi
                   gh issue create \
+                      --label tested-up-to-failure \
                       --title "$title" \
                       --body "$(cat <<EOF
-                  PHPUnit validation against WordPress \`$FULL\` failed during the scheduled \`Update Tested up to\` run.
+                  Validation against WordPress \`$FULL\` failed during the \`Update Tested up to\` workflow.
 
                   Run: $RUN_URL
 
-                  Daily runs will keep retrying until this issue is closed. Close it once the plugin is patched or wp.org ships an update.
+                  Daily runs will keep retrying. While this issue is open it suppresses duplicate failure reports for WordPress $VERSION; it will auto-close once validation passes against a later patch release.
                   EOF
                   )"
 
     close-failure-issue:
         name: Close validation-failure issue on success
         needs: [check, validate]
-        if: needs.validate.result == 'success'
+        # Match notify-failure's gate so a branch-dispatch can't auto-close a
+        # real tracking issue based on branch-only changes.
+        if: needs.validate.result == 'success' && github.ref == 'refs/heads/trunk'
         runs-on: ubuntu-latest
         permissions:
             issues: write
@@ -167,8 +187,16 @@ jobs:
               # even after a later release unsticks the workflow.
               run: |
                   set -euo pipefail
+                  # search/issues is permissive when the label doesn't exist —
+                  # gh issue list --label would fail in a repo that's never seen
+                  # a failure (and so never had the label created). --paginate
+                  # so the lookup still works in a repo with >100 open failures.
                   title="Validate failed against WordPress $VERSION"
-                  existing=$(gh issue list --state open --search "in:title \"$title\"" --json number --jq '.[0].number // empty')
+                  existing=$(gh api -X GET search/issues \
+                      -f q="repo:$GH_REPO is:issue is:open label:tested-up-to-failure" \
+                      -f per_page=100 --paginate \
+                      --jq ".items[] | select(.title == \"$title\") | .number" \
+                      | head -1)
                   if [ -z "$existing" ]; then
                       echo "No matching open issue to close."
                       exit 0
@@ -178,7 +206,10 @@ jobs:
 
     update:
         needs: [check, validate]
-        if: needs.check.outputs.needs_update == 'true'
+        # Pin to trunk so a workflow_dispatch from a feature branch can't
+        # auto-merge that branch's changes into trunk (peter-evans/create-pull-request
+        # would otherwise produce a PR from the dispatched branch's tree).
+        if: needs.check.outputs.needs_update == 'true' && github.ref == 'refs/heads/trunk'
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Two related follow-ups to #36:

### 1. Trunk-gate the side-effect jobs (`update`, `notify-failure`, `close-failure-issue`)

#36 deliberately relaxed `check`'s ref gate so `workflow_dispatch` from a feature branch can exercise the comparison logic. But `update`, `notify-failure`, and `close-failure-issue` were also left ungated, which means:

- A manual dispatch from a feature branch can ask `peter-evans/create-pull-request` to produce a PR from that branch's tree (not just a readme bump) and auto-merge it into `trunk`.
- A passing/failing validate run from a branch can open or close a real tracking issue based on branch-only changes.

All three jobs now also require `github.ref == 'refs/heads/trunk'`. `check` and `validate` remain reachable from feature-branch dispatch so the pipeline can still be tested by hand; the side-effect channels are now trunk-only.

### 2. Track failure issues by label instead of fuzzy title search

The old dedupe was `gh issue list --search "in:title \"Validate failed against WordPress 6.10\""`. Two real failure modes:

- GitHub's search tokenizes version strings on punctuation, so a search for `6.10` could match an open issue titled `6.1` (or conversely match `6.10.1` once that title style existed).
- An unrelated human-opened issue whose title happened to contain the phrase could be auto-closed by `close-failure-issue`.

`notify-failure` now idempotently creates a `tested-up-to-failure` label (`gh label create --force`) and applies it to every issue it opens. Both jobs filter by that label first, then check title equality exactly via `jq`. The matching universe is restricted to issues this workflow itself created, so the title check can no longer misfire.

`close-failure-issue` uses the `search/issues` API rather than `gh issue list --label` so it returns an empty result (instead of erroring) in a repo that's never seen a failure and therefore never had the label created.

### 3. Wording

Issue body switched from "PHPUnit validation against WordPress … failed during the scheduled run" to "Validation against WordPress … failed during the `Update Tested up to` workflow." — this PR's `validate` step is PHPUnit, but the same workflow is now rolled out to 9 other repos where validate runs Playwright/e2e or both; the wording is now generic and trigger-agnostic.

## Test plan

- [ ] Dispatch `Update Tested up to` from a feature branch with a stale `readme.txt` → `check` and `validate` run; `update`, `notify-failure`, `close-failure-issue` are all skipped due to the trunk gate.
- [ ] Confirm the `tested-up-to-failure` label is created automatically the first time `notify-failure` runs on a real failure.
- [ ] Confirm a second `notify-failure` run for the same WP version reuses the existing issue (dedupe) rather than opening a duplicate.
- [ ] Confirm `close-failure-issue` correctly closes the issue when validation later passes against a patch release of the same major.minor.
