### PR TITLE
Convert readme.txt to README.md

### DIFF
--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -10,7 +10,7 @@ on:
         # push, trunk has unshipped code from a prior commit — cut a release tag
         # to publish via deploy.yml instead.
         paths:
-            - readme.txt
+            - README.md
             - .wordpress-org/**
 jobs:
     trunk:

--- a/.github/workflows/update-tested-up-to.yml
+++ b/.github/workflows/update-tested-up-to.yml
@@ -31,7 +31,7 @@ jobs:
         steps:
             - uses: actions/checkout@v6
               with:
-                  sparse-checkout: readme.txt
+                  sparse-checkout: README.md
                   sparse-checkout-cone-mode: false
 
             - name: Compare latest WordPress against readme
@@ -49,9 +49,9 @@ jobs:
                       echo "Failed to derive major.minor from '$latest'" >&2
                       exit 1
                   fi
-                  current=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' readme.txt)
+                  current=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' README.md)
                   if [ -z "$current" ]; then
-                      echo "Could not find 'Tested up to:' header in readme.txt" >&2
+                      echo "Could not find 'Tested up to:' header in README.md" >&2
                       exit 1
                   fi
                   sorted=$(printf '%s\n%s\n' "$current" "$short" | sort -V)
@@ -214,15 +214,15 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
-            - name: Update readme.txt
+            - name: Update README.md
               shell: bash
               env:
                   TARGET: ${{ needs.check.outputs.version }}
                   PREVIOUS: ${{ needs.check.outputs.previous }}
               run: |
                   set -euo pipefail
-                  sed -i -E "s/^([Tt]ested up to:[[:space:]]+).*/\1$TARGET/" readme.txt
-                  new=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' readme.txt)
+                  sed -i -E "s/^([Tt]ested up to:[[:space:]]+).*/\1$TARGET/" README.md
+                  new=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' README.md)
                   if [ "$new" != "$TARGET" ]; then
                       echo "sed did not produce expected value (got '$new')" >&2
                       exit 1
@@ -243,7 +243,7 @@ jobs:
                   body: |
                       WordPress ${{ needs.check.outputs.full }} is the latest stable release.
 
-                      Bumps `Tested up to` in readme.txt from ${{ needs.check.outputs.previous }} to ${{ needs.check.outputs.version }} (major.minor of ${{ needs.check.outputs.full }}).
+                      Bumps `Tested up to` in README.md from ${{ needs.check.outputs.previous }} to ${{ needs.check.outputs.version }} (major.minor of ${{ needs.check.outputs.full }}).
                   branch: chore/tested-up-to-${{ needs.check.outputs.version }}
                   delete-branch: true
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-=== WP Author Slug ===
+# WP Author Slug
 Contributors: obenland
 Tags: security, slug, author, author archive, url, permalink
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=XVPLJZ3VH4GCN
@@ -8,7 +8,7 @@ Stable tag: 6
 
 Add a layer of security and prevent your login name from being shown in the author archive's URL.
 
-== Description ==
+## Description
 
 This plugin replaces the author slug with a sanitized version of the user's display name.
 
@@ -18,61 +18,61 @@ in the author archive's URL, which works towards your friendly URLs with using y
 DO NOT use this on a site with more than 1000 registered users, as updating all of their nicenames at once might break your site.
 
 
-== Installation ==
+## Installation
 
 1. Download WP Author Slug.
 2. Unzip the folder into the `/wp-content/plugins/` directory.
 3. Activate the plugin through the 'Plugins' menu in WordPress.
 
 
-== Changelog ==
+## Changelog
 
-= 6 =
+### 6
 * Escaped donate link output in `plugin_row_meta` to harden against malformed URLs.
 * Tested with WordPress 6.9.
 
-= 5 =
+### 5
 * Added conflict detection for author slugs that match existing page slugs. Props @knutsp.
 * Tested with WordPress 6.8.
 
-= 4 =
+### 4
 * Moved clean up to plugin deactivation. This makes sure author slugs are only modified with the plugin active.
 * Updated utility class.
 * Tested with WordPress 6.1.
 
-= 3 =
+### 3
 * Maintenance release.
 * Checks if keys and properties exist before using them.
 * Tested with WordPress 5.6.
 
-= 2 =
+### 2
 * Maintenance release.
 * Updated code to adhere to WordPress Coding Standards.
 * Tested with WordPress 5.0.
 
-= 1.3.0 =
+### 1.3.0
 * Maintenance release.
 * Tested with WordPress 4.0.
 
-= 1.2.2 =
+### 1.2.2
 * Updated utility class.
 * Tested with WordPress 3.4.1.
 
-= 1.2.1 =
+### 1.2.1
 * Updated uninstall.php and activation hook to use WordPress User API instead of custom queries.
 * Updated utility class.
 
-= 1.2 =
+### 1.2
 * Tested for WordPress 3.3.1.
 
-= 1.1 =
+### 1.1
 * Tested for WordPress 3.1.1.
 * Added complete uninstall routine.
 * Added compatibility for pre-3.1 multisite installs.
 
-= 1.0 =
+### 1.0
 * Initial Release.
 
 
-== Upgrade Notice ==
+## Upgrade Notice
 Hardened donate link escaping in the plugin row meta. Tested with WordPress 6.9.


### PR DESCRIPTION
## Summary

Renames `readme.txt` to `README.md` (GitHub renders it on the repo home) without giving up the wp.org plugin page.

WordPress.org's plugin-directory parser accepts either filename — its lookup regex is `!(?:^|/)readme\.(txt|md)$!i` (case-insensitive, .md included) — and the section grammar already supports `##` headers alongside `==`. The WP field block (`Contributors:`, `Tested up to:`, `Stable tag:`, …) stays in the same `Field: Value` format in both files. Within sections, `### x.y.z` becomes the changelog entry form (since `###` doesn't end a section).

Workflows that read or write the readme are updated to point at `README.md`:

- `update-tested-up-to.yml` — sparse-checkout, the `[Tt]ested up to:` sed/grep, and the PR body
- `push-asset-readme-update.yml` / `plugin-asset-update.yml` — path triggers
- `phpunit*.yml`, `playwright*.yml`, `test-e2e.yml` — `paths-ignore` arrays

For uploads-unleashed, `release.yml`'s changelog-insertion logic is also rewritten: it now greps for `^### <tag>$` and inserts after `^## Changelog`, and `.distignore` no longer excludes `README.md` from the SVN sync.

## Test plan

- [ ] GitHub renders README.md on the repo home.
- [ ] Next scheduled `update-tested-up-to` run finds the `Tested up to:` header in README.md and behaves the same as before.
- [ ] wp.org plugin page continues to show the readme content on the next deploy (parser picks up README.md via the case-insensitive lookup).
