### PR TITLE
Fix wp.org import warnings (License + Tags)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # WP Author Slug
 Contributors: obenland
-Tags: security, slug, author, author archive, url, permalink
+Tags: security, slug, author, author archive, url
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=XVPLJZ3VH4GCN
 Requires at least: 3.0
 Tested up to: 6.9
 Stable tag: 6
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 Add a layer of security and prevent your login name from being shown in the author archive's URL.
 


### PR DESCRIPTION
Addresses the two warnings wp.org's importer surfaced after the readme.txt → README.md rename. See commit message for details. Pre-existing in the original readme.txt; not introduced by the rename.