### PR TITLE
Tell the deploy action README.md is the readme source

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,3 +14,4 @@ jobs:
               env:
                   SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
                   SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+                  README_NAME: README.md


### PR DESCRIPTION
## Summary
- Adds `README_NAME: README.md` to the `10up/action-wordpress-plugin-deploy` step.
- Without it, the action defaults to looking for `readme.txt`. This repo only has `README.md`, so on the next tag push the action would either fail or re-create a default `readme.txt` and reintroduce WordPress.org plugin-importer warnings about missing fields (License, Stable tag, etc.).

## Test plan
- [ ] After merge, the next tag push deploys cleanly with README.md as the canonical readme.
- [ ] WordPress.org plugin page reports no warnings after the next import scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)