### PR TITLE
Fix Update Tested up to workflow: sign commits, bypass redundant PR checks

### DIFF
--- a/.github/workflows/update-tested-up-to.yml
+++ b/.github/workflows/update-tested-up-to.yml
@@ -237,6 +237,7 @@ jobs:
                   # and so the eventual --auto squash-merge is attributed to a real
                   # identity and triggers push-asset-readme-update.yml on trunk.
                   token: ${{ secrets.WORKFLOW_PAT }}
+                  sign-commits: true
                   base: trunk
                   commit-message: 'Bump Tested up to ${{ needs.check.outputs.version }}'
                   title: 'Bump Tested up to ${{ needs.check.outputs.version }}'
@@ -268,8 +269,10 @@ jobs:
                           gh pr merge --squash --delete-branch "$PR"
                           ;;
                       BLOCKED | BEHIND)
-                          # Required checks pending or branch behind base — queue for auto-merge.
-                          gh pr merge --auto --squash --delete-branch "$PR"
+                          # Required PR checks (PHPUnit/Playwright) skip README-only changes, so they
+                          # never report on this PR. The validate job already ran the same tests
+                          # against latest WP before opening the PR, so bypass branch protection.
+                          gh pr merge --admin --squash --delete-branch "$PR"
                           ;;
                       *)
                           echo "PR #$PR is in unexpected state: $state" >&2


### PR DESCRIPTION
Adds `sign-commits: true` so bumps are verified, and switches the merge step from `--auto` to `--admin` since the required PR checks (PHPUnit/Playwright) skip README-only changes and never report — the workflow's `validate` job already runs those tests against latest WP before opening the PR.