### PR TITLE
Add README.md to PHPUnit workflow path filter

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -25,6 +25,7 @@ on:
             - 'package-lock.json'
             - '.nvmrc'
             - '.github/workflows/phpunit.yml'
+            - 'README.md'
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Adds `README.md` to the `paths:` list under `on.pull_request:` in `.github/workflows/phpunit.yml` so the workflow runs when the README changes.