### PR TITLE
Move scheduled tested-up-to run to Fridays at 01:00 UTC

### DIFF
--- a/.github/workflows/update-tested-up-to.yml
+++ b/.github/workflows/update-tested-up-to.yml
@@ -2,7 +2,7 @@ name: Update Tested up to
 
 on:
     schedule:
-        - cron: '0 9 * * 1'
+        - cron: '0 1 * * 5'
     workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Shifts the update-tested-up-to schedule from Mondays 09:00 UTC to Fridays 01:00 UTC, matching the rest of the fleet.